### PR TITLE
Altered pkron so it allows number of ops to be the equal to len(dims)

### DIFF
--- a/quimb/core.py
+++ b/quimb/core.py
@@ -1837,8 +1837,11 @@ def pkron(op, dims, inds, **ikron_opts):
     b = ikron(op, [sz_in, sz // sz_in], 0, **ikron_opts)
 
     # inverse of inds
-    inds_out, dims_out = zip(
-        *((i, x) for i, x in enumerate(dims) if i not in inds))
+    if len(dims) == len(inds):
+        inds_out, dims_out = (), ()
+    else:
+        inds_out, dims_out = zip(
+            *((i, x) for i, x in enumerate(dims) if i not in inds))
 
     # current order and dimensions of system
     p = [*inds, *inds_out]


### PR DESCRIPTION
I've created a possible fix for the problem I raised in issue #17. The fix is that if ```len(dims) == len(inds)``` then ```pkron``` will set ```inds_out``` and ```dims_out``` to be empty tuples. Otherwise ```pkron``` behaves as before.  