### PR TITLE
Feature/mpo apply

### DIFF
--- a/quimb/tensor/tensor_1d.py
+++ b/quimb/tensor/tensor_1d.py
@@ -2476,8 +2476,8 @@ class MatrixProductOperator(TensorNetwork1DFlat,
         A, x = self.copy(), other.copy()
 
         # align the indices
-        A.upper_ind_id = "__tmp{}__"
-        A.lower_ind_id = x.site_ind_id
+        A.lower_ind_id = "__tmp{}__"
+        A.upper_ind_id = x.site_ind_id
         x.reindex_sites("__tmp{}__", inplace=True)
 
         # form total network and contract each site
@@ -2525,22 +2525,22 @@ class MatrixProductOperator(TensorNetwork1DFlat,
 
         For an MPS::
 
-            other: x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x
                    | | | | | | | | | | | | | | | | | |
              self: A-A-A-A-A-A-A-A-A-A-A-A-A-A-A-A-A-A
                    | | | | | | | | | | | | | | | | | |
+            other: x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x
 
                                    -->
 
-              out: y=y=y=y=y=y=y=y=y=y=y=y=y=y=y=y=y=y
                    | | | | | | | | | | | | | | | | | |   <- other.site_ind_id
+              out: y=y=y=y=y=y=y=y=y=y=y=y=y=y=y=y=y=y
 
         For an MPO::
 
                    | | | | | | | | | | | | | | | | | |
-            other: B-B-B-B-B-B-B-B-B-B-B-B-B-B-B-B-B-B
-                   | | | | | | | | | | | | | | | | | |
              self: A-A-A-A-A-A-A-A-A-A-A-A-A-A-A-A-A-A
+                   | | | | | | | | | | | | | | | | | |
+            other: B-B-B-B-B-B-B-B-B-B-B-B-B-B-B-B-B-B
                    | | | | | | | | | | | | | | | | | |
 
                                    -->
@@ -2573,6 +2573,8 @@ class MatrixProductOperator(TensorNetwork1DFlat,
         else:
             raise TypeError("Can only Dot with a MatrixProductOperator or a "
                             "MatrixProductState, got {}".format(type(other)))
+
+    dot = apply
 
     def trace(self, left_inds=None, right_inds=None):
         """Take the trace of this MPO.

--- a/tests/test_tensor/test_tensor_1d.py
+++ b/tests/test_tensor/test_tensor_1d.py
@@ -712,6 +712,8 @@ class TestMatrixProductOperator:
         assert isinstance(y, MatrixProductState)
         assert len(y.tensors) == 8
         assert y.site_ind_id == site_ind_id
+        Ad, xd, yd = A.to_dense(), x.to_dense(), y.to_dense()
+        assert_allclose(Ad @ xd, yd)
 
     @pytest.mark.parametrize("cyclic", (False, True))
     def test_sites_mpo_mps_product(self, cyclic):


### PR DESCRIPTION
I would like to point to several issues with `MatrixProductOperator.apply`:

1. First, something that is related indirectly: attribute names `lower_ind_id` and `upper_ind_id` are ambiguous. If the "bra-ket" notation is used in the code (and it is used) the corresponding labels should be left-right, not top-bottom. Otherwise it is not clear whether "upper" are contracted with bra or ket.

2. Now the point: `MatrixProductOperator._apply_mps` and `MatrixProductOperator._apply_mpo` behave differently. `self` is on top of `other` in `_apply_mpo` while it is underneath `other` in `_apply_mps`. This is inconsistent.

3. The docstring for `apply` clearly shows that the `other` is on top of `self` in the MPO case. This is also inconsistent.

PR deals with 2 and 3 but not 1.