### PR TITLE
Approximate norm in case of LinearOperator supplied to Evolution as the ham

### DIFF
--- a/quimb/evo.py
+++ b/quimb/evo.py
@@ -259,9 +259,6 @@ class Evolution(object):
     int_small_step : bool, optional
         If ``method='integrate'``, whether to use a low or high order
         integrator to give naturally small or large steps.
-    initial_norm : float, optional
-        An operator norm value (or estimate of) for ``ham`` (at t=t0 if time-dependent). 
-        If this is not supplied, an attempt to calculate will be made if needed.
     expm_backend : {'auto', 'scipy', 'slepc'}
         How to perform the expm_multiply function if ``method='expm'``. Can
         further specifiy ``'slepc-krylov'``, or ``'slepc-expokit'``.
@@ -277,7 +274,6 @@ class Evolution(object):
                  compute=None,
                  method='integrate',
                  int_small_step=False,
-                 initial_norm=None,
                  expm_backend='AUTO',
                  expm_opts=None,
                  progbar=False):
@@ -290,7 +286,6 @@ class Evolution(object):
 
         self._setup_callback(compute)
         self._method = method
-        self._initial_norm = initial_norm
 
         if method == 'solve' or isinstance(ham, (tuple, list)):
             if callable(ham):
@@ -397,10 +392,7 @@ class Evolution(object):
 
         # 5th order stpper or 8th order stepper
         int_mthd, step_fct = ('dopri5', 150) if small_step else ('dop853', 50)
-        if self._initial_norm is None:
-            first_step = norm(H0, 'f') / step_fct
-        else:
-            first_step = self._initial_norm / step_fct
+        first_step = norm(H0, 'f') / step_fct
 
         self._stepper.set_integrator(int_mthd, nsteps=0, first_step=first_step)
 

--- a/quimb/evo.py
+++ b/quimb/evo.py
@@ -259,6 +259,9 @@ class Evolution(object):
     int_small_step : bool, optional
         If ``method='integrate'``, whether to use a low or high order
         integrator to give naturally small or large steps.
+    initial_norm : float, optional
+        An operator norm value (or estimate of) for ``ham`` (at t=t0 if time-dependent). 
+        If this is not supplied, an attempt to calculate will be made if needed.
     expm_backend : {'auto', 'scipy', 'slepc'}
         How to perform the expm_multiply function if ``method='expm'``. Can
         further specifiy ``'slepc-krylov'``, or ``'slepc-expokit'``.
@@ -274,6 +277,7 @@ class Evolution(object):
                  compute=None,
                  method='integrate',
                  int_small_step=False,
+                 initial_norm=None,
                  expm_backend='AUTO',
                  expm_opts=None,
                  progbar=False):
@@ -286,6 +290,7 @@ class Evolution(object):
 
         self._setup_callback(compute)
         self._method = method
+        self._initial_norm = initial_norm
 
         if method == 'solve' or isinstance(ham, (tuple, list)):
             if callable(ham):
@@ -392,7 +397,10 @@ class Evolution(object):
 
         # 5th order stpper or 8th order stepper
         int_mthd, step_fct = ('dopri5', 150) if small_step else ('dop853', 50)
-        first_step = norm(H0, 'f') / step_fct
+        if self._initial_norm is None:
+            first_step = norm(H0, 'f') / step_fct
+        else:
+            first_step = self._initial_norm / step_fct
 
         self._stepper.set_integrator(int_mthd, nsteps=0, first_step=first_step)
 

--- a/quimb/linalg/approx_spectral.py
+++ b/quimb/linalg/approx_spectral.py
@@ -139,6 +139,27 @@ def norm_fro(a):
     """
     return sqrt(inner(a, a))
 
+def norm_fro_approx(A, **kwargs):
+    r"""Calculate the approximate frobenius norm of any hermitian linear
+    operator:
+
+    .. math::
+
+        \mathrm{Tr} \left[ A^{\dagger} A \right]
+
+    Parameters
+    ----------
+    A : linear operator like
+        Operator with a dot method, assumed to be hermitian, to estimate the
+        frobenius norm of.
+    kwargs
+        Supplied to :func:`approx_spectral_function`.
+
+    Returns
+    -------
+    float
+    """
+    return approx_spectral_function(A, lambda x: x**2, **kwargs)**0.5
 
 def random_rect(shape, dist='rademacher', orthog=False, norm=True,
                 seed=False, dtype=complex):

--- a/tests/test_linalg/test_approx_spectral.py
+++ b/tests/test_linalg/test_approx_spectral.py
@@ -344,5 +344,5 @@ class TestSpecificApproxQuantities:
         A = rand_herm(2**5)
         actual_norm_fro = norm_fro(A)
         approx_norm_fro = norm_fro_approx(A, tol=1e-2, bsz=bsz)
-        assert_allclose(actual_norm_fro, approx_norm_fro, rtol=1e-2)
+        assert_allclose(actual_norm_fro, approx_norm_fro, rtol=1e-1)
         

--- a/tests/test_linalg/test_approx_spectral.py
+++ b/tests/test_linalg/test_approx_spectral.py
@@ -30,6 +30,8 @@ from quimb.linalg.approx_spectral import (
     entropy_subsys_approx,
     logneg_subsys_approx,
     negativity_subsys_approx,
+    norm_fro,
+    norm_fro_approx,
 )
 from quimb.linalg import SLEPC4PY_FOUND
 
@@ -336,3 +338,11 @@ class TestSpecificApproxQuantities:
         actual_neg = negativity(rho_ab, DIMS[:-1], 0)
         approx_neg = negativity_subsys_approx(psi_abc, DIMS, 0, 1, bsz=bsz)
         assert_allclose(actual_neg, approx_neg, rtol=2e-1)
+
+    @pytest.mark.parametrize("bsz", [1, 2, 5])
+    def test_norm_fro_approx(self, bsz):
+        A = rand_herm(2**5)
+        actual_norm_fro = norm_fro(A)
+        approx_norm_fro = norm_fro_approx(A, tol=1e-2, bsz=bsz)
+        assert_allclose(actual_norm_fro, approx_norm_fro, rtol=1e-2)
+        


### PR DESCRIPTION
Instantiating Evolution with a ham that is a custom linear operator failed, because it tries to compute the Frobenius norm to set the first step-size. It ultimately failed on a call of the 'ravel' method.

This change allow for the norm to be estimated in this case