### PR TITLE
Add a simple test for the time-dependent Evolution code

### DIFF
--- a/quimb/evo.py
+++ b/quimb/evo.py
@@ -289,6 +289,10 @@ class Evolution(object):
         self._setup_callback(compute)
         self._method = method
 
+        if self._isdop and callable(ham):
+                raise TypeError("You can't use a time-dependent Hamiltonian "
+                                "for density operator evolution.")
+            
         if method == 'solve' or isinstance(ham, (tuple, list)):
             if callable(ham):
                 raise TypeError("You can't use the 'solve' method "


### PR DESCRIPTION
New parameter in the test_evo_ham test to check the time-dependent case. 

This doesn't really check an actual time-dependent example - it fakes a time-dependent Hamiltonian by wrapping a time-independent one as a callable so the the integrator gets called as if it were time-dependent.

This also adds some code to evo.py: If try to initialize Evolution with a time-dependent ham and a density op, raise a TypeError - the test checks this happens.

(Note: I think it should be possible to really implement time-dependent evolution of a density operator at some point).

