### PR TITLE
stop hamiltonian_builder coercing dtype if explicitly given

### DIFF
--- a/quimb/gen/operators.py
+++ b/quimb/gen/operators.py
@@ -427,7 +427,8 @@ def hamiltonian_builder(fn):
     kwargs ``stype`` and ``sparse``. This assumes the core function always
     builds the hamiltonian in sparse form. The wrapper then:
 
-    1. Checks if the operator is real
+    1. Checks if the operator is real and, if so, discards imaginary part if no
+       explicity `dtype` was given
     2. Converts the operator to dense or the correct sparse form
     3. Makes the operator immutable so it can be safely cached
     """
@@ -436,7 +437,7 @@ def hamiltonian_builder(fn):
     def ham_fn(*args, stype='csr', sparse=False, **kwargs):
         H = fn(*args, **kwargs)
 
-        if isreal(H):
+        if kwargs.get('dtype', None) is None and isreal(H):
             H = H.real
 
         if not sparse:

--- a/tests/test_gen/test_operators.py
+++ b/tests/test_gen/test_operators.py
@@ -35,6 +35,9 @@ def test_hamiltonian_builder(sparse, stype, dtype):
     if sparse:
         assert H.format == stype
 
+    with pytest.raises(ValueError): # check immutability
+        H[0,0] = 100
+        
     if dtype == "don't pass":
         H = simple_ham_complex(sparse=sparse, stype=stype)
     elif dtype is np.float64:
@@ -52,6 +55,10 @@ def test_hamiltonian_builder(sparse, stype, dtype):
     assert qu.isdense(H) != sparse
     if sparse:
             assert H.format == stype
+
+    with pytest.raises(ValueError): # check immutability
+        H[0,0] = 100
+            
     return
                 
 class TestSpinOperator:


### PR DESCRIPTION
include a comprehensive test that hamiltonian_builder does what it says