### PR TITLE
Evolution: allow callback funcs to take in Hamiltonian

### DIFF
--- a/quimb/evo.py
+++ b/quimb/evo.py
@@ -12,7 +12,7 @@ from scipy.integrate import complex_ode
 from scipy.sparse.linalg import LinearOperator
 
 from .core import (qarray, isop, ldmul, rdmul, explt,
-                   dot, issparse, qu, eye, dag)
+                   dot, issparse, qu, eye, dag, make_immutable)
 from .linalg.base_linalg import eigh, norm, expm_multiply
 from .linalg.approx_spectral import norm_fro_approx
 from .utils import continuous_progbar, progbar
@@ -263,12 +263,18 @@ class Evolution(object):
         Governing Hamiltonian, if tuple then assumed to contain
         ``(eigvals, eigvecs)`` of presolved system. If callable (but not a SciPy 
         ``LinearOperator``), assume a time-dependent hamiltonian such that ``ham(t)`` 
-        is the Hamiltonian at time ``t``.
+        is the Hamiltonian at time ``t``. In this case, the latest call to ``ham`` will
+        be cached (and made immutable) in case it is needed by callbacks passed to 
+        ``compute``.
     t0 : float, optional
         Initial time (i.e. time of state ``p0``), defaults to zero.
     compute : callable, or dict of callable, optional
-        Function(s) to compute on the state at each time step, called
-        with args (t, pt). If supplied with:
+        Function(s) to compute on the state at each time step. Function(s) should
+        take args (t, pt) or (t, pt, ham) if the Hamiltonian is required. If ham
+        is required, it will be passed in to the function exactly as given to
+        this ``Evolution`` instance, except if ``method`` is ``'solve'``, in which
+        case it will be passed in as the solved system ``(eigvals, eigvecs)``.
+        If supplied with:
 
             - single callable : ``Evolution.results`` will contain the results
               as a list,
@@ -319,6 +325,16 @@ class Evolution(object):
 
         self._timedep = callable(ham) and not isinstance(ham, LinearOperator)
 
+        if self._timedep:
+            # make the time dependent hamiltonian be cached in case callbacks use it
+            noncacheing_ham = ham
+            @functools.lru_cache(1)
+            def ham(t):                 
+                Ht = noncacheing_ham(t) 
+                if not isinstance(Ht, LinearOperator):
+                    make_immutable(Ht)
+                return Ht
+    
         self._setup_callback(compute)
         self._method = method
 
@@ -354,44 +370,51 @@ class Evolution(object):
     def _setup_callback(self, fn):
         """Setup callbacks in the correct place to compute into _results
         """
+        # if fn is None there is no callback, but possible make a dummy
+        #   one if progbar needs updating
         if fn is None:
             step_callback = None
             if not self._progbar:
                 int_step_callback = None
             else:
-                def int_step_callback(t, y):
+                def int_step_callback(t, y, H):
                     pass
+                
+        # else fn is a dict of callbacks or a single callback        
+        else:
+            # try just passing time and state to a single callback function
+            # if it fails, pass time, state and hamiltonian
+            def single_callback(fn, t, pt, H):
+                try:
+                    fn_result = fn(t, pt)
+                except TypeError as e:
+                    if 'positional' in e.args[0]:
+                        fn_result = fn(t, pt, H)
+                    else:
+                        raise
+                return fn_result
+                
+            # dict of funcs input -> dict of funcs output
+            if isinstance(fn, dict):
+                self._results = {k: [] for k in fn}
+                def step_callback(t, pt, H):
+                    for k, v in fn.items():
+                        fn_result = single_callback(v, t, pt, H)
+                        self._results[k].append(fn_result)
 
-        # dict of funcs input -> dict of funcs output
-        elif isinstance(fn, dict):
-            self._results = {k: [] for k in fn}
-
-            @functools.wraps(fn)
-            def step_callback(t, pt):
-                for k, v in fn.items():
-                    self._results[k].append(v(t, pt))
+            # else results -> single list of outputs of fn
+            else:
+                self._results = []
+                def step_callback(t, pt, H):
+                    fn_result = single_callback(fn, t, pt, H)
+                    self._results.append(fn_result)
 
             # For the integration callback, additionally need to convert
             #   back to 'quantum' (column vector) form
-            @functools.wraps(fn)
-            def int_step_callback(t, y):
+            def int_step_callback(t, y, H):
                 pt = qarray(y.reshape(self._d, -1))
-                for k, v in fn.items():
-                    self._results[k].append(v(t, pt))
-
-        # else results -> single list of outputs of fn
-        else:
-            self._results = []
-
-            @functools.wraps(fn)
-            def step_callback(t, pt):
-                self._results.append(fn(t, pt))
-
-            @functools.wraps(fn)
-            def int_step_callback(t, y):
-                pt = qarray(y.reshape(self._d, -1))
-                self._results.append(fn(t, pt))
-
+                step_callback(t, pt, H)
+                
         self._step_callback = step_callback
         self._int_step_callback = int_step_callback
 
@@ -444,7 +467,9 @@ class Evolution(object):
 
         # Set step_callback to be evaluated with args (t, y) at each step
         if self._int_step_callback is not None:
-            self._stepper.set_solout(self._int_step_callback)
+            def solout(t, y):
+                self._int_step_callback(t, y, self._ham)
+            self._stepper.set_solout(solout)
 
         self._stepper.set_initial_value(self._p0.A.reshape(-1), self.t0)
 
@@ -464,7 +489,7 @@ class Evolution(object):
 
         # compute any callbacks into -> self._results
         if self._step_callback is not None:
-            self._step_callback(t, self._pt)
+            self._step_callback(t, self._pt, self._ham)
 
     def _update_to_solved_ket(self, t):
         """Update simulation consisting of a solved hamiltonian and a
@@ -477,7 +502,7 @@ class Evolution(object):
 
         # compute any callbacks into -> self._results
         if self._step_callback is not None:
-            self._step_callback(t, self._pt)
+            self._step_callback(t, self._pt, self._ham)
 
     def _update_to_solved_dop(self, t):
         """Update simulation consisting of a solved hamiltonian and a
@@ -491,7 +516,7 @@ class Evolution(object):
 
         # compute any callbacks into -> self._results
         if self._step_callback is not None:
-            self._step_callback(t, self._pt)
+            self._step_callback(t, self._pt, self._ham)
 
     def _update_to_integrate(self, t):
         """Update simulation consisting of unsolved hamiltonian.
@@ -511,7 +536,7 @@ class Evolution(object):
             with continuous_progbar(self.t, t) as pbar:
                 if self._int_step_callback is not None:
                     def solout(t, y):
-                        self._int_step_callback(t, y)
+                        self._int_step_callback(t, y, self._ham)
                         pbar.cupdate(t)
                 else:
                     def solout(t, _):

--- a/tests/test_evo.py
+++ b/tests/test_evo.py
@@ -290,7 +290,8 @@ class TestEvolution:
     @mark.parametrize("dop", [False, True])
     @mark.parametrize("linop", [False, True])
     @mark.parametrize("num_callbacks", [0, 1, 2])
-    def test_evo_timedep_adiabatic_with_callbacks(self, dop, linop, num_callbacks):
+    def test_evo_timedep_adiabatic_with_callbacks(self, dop, linop,
+                                                  num_callbacks):
         # tests time dependent Evolution via an adiabatic sweep with:
         #   a) no callbacks
         #   b) 1 callback that accesses the time-dependent Hamiltonian
@@ -298,7 +299,7 @@ class TestEvolution:
 
         if num_callbacks > 0 and (dop or linop):
             # should implement this at some point
-            return 
+            return
         L = 6
         T = 20
 
@@ -333,16 +334,15 @@ class TestEvolution:
         else:
             def gs_overlap(t, pt, H):
                 evals, evecs = eigs_scipy(H(t), k=1, which='SA')
-                return np.abs(qu.dot(pt.T, qu.qu(evecs[:,0])))**2
+                return np.abs(qu.dot(pt.T, qu.qu(evecs[:, 0])))**2
 
             if num_callbacks == 1:
                 compute = gs_overlap
             if num_callbacks == 2:
                 def norm(t, pt):
                     return qu.dot(pt.T, pt)
-                compute = {'norm' : norm, 'gs_overlap' : gs_overlap} 
+                compute = {'norm': norm, 'gs_overlap': gs_overlap}
             evo = qu.Evolution(p0, ham, compute=compute, progbar=True)
-            
         evo.update_to(T)
 
         # final state should now overlap much more with second hamiltonian GS
@@ -361,7 +361,7 @@ class TestEvolution:
             assert ((np.array(norm_results) - 1.0) < 1e-3).all()
             # check that we stayed in the ground state the whole time
             assert ((np.array(gs_overlap_results) - 1.0) < 1e-3).all()
-        
+
     def test_evo_at_times(self):
         ham = qu.ham_heis(2, cyclic=False)
         p0 = qu.up() & qu.down()
@@ -408,15 +408,14 @@ class TestEvolution:
         def some_other_quantity(_, pt):
             return qu.logneg(pt)
 
-        # check that hamiltonian gets accepted without error for all the methods
+        # check that hamiltonian gets accepted without error for all methods
         def some_other_quantity_accepting_ham(t, pt, H):
             return qu.logneg(pt)
-        
-        evo = qu.Evolution(p0, ham, method=method,
-                           compute={'t': some_quantity,
-                                    'logneg': some_other_quantity,
-                                    'logneg_ham': some_other_quantity_accepting_ham})
 
+        compute = {'t': some_quantity, 'logneg': some_other_quantity,
+                   'logneg_ham': some_other_quantity_accepting_ham}
+
+        evo = qu.Evolution(p0, ham, method=method, compute=compute)
         manual_lns = []
         for pt in evo.at_times(np.linspace(0, 1, 6)):
             manual_lns.append(qu.logneg(pt))
@@ -429,7 +428,8 @@ class TestEvolution:
         for t, ln, ln_ham in zip(ts, lns, lns_ham):
             if abs(t - 0.8) < 1e-12:
                 assert abs(ln - manual_lns[4]) < 1e-12
-                assert ln == ln_ham # check that accepting hamiltonian didn't mess it up
+                # check that accepting hamiltonian didn't mess it up
+                assert ln == ln_ham
                 checked = True
         assert checked
 

--- a/tests/test_evo.py
+++ b/tests/test_evo.py
@@ -16,6 +16,8 @@ from quimb.evo import (
 )
 from .test_linalg.test_slepc_linalg import slepc4py_test
 
+from quimb.linalg.base_linalg import eigs_scipy
+
 
 @fixture
 def psi_dot():
@@ -287,7 +289,16 @@ class TestEvolution:
 
     @mark.parametrize("dop", [False, True])
     @mark.parametrize("linop", [False, True])
-    def test_evo_timedep_adiabatic(self, dop, linop):
+    @mark.parametrize("num_callbacks", [0, 1, 2])
+    def test_evo_timedep_adiabatic_with_callbacks(self, dop, linop, num_callbacks):
+        # tests time dependent Evolution via an adiabatic sweep with:
+        #   a) no callbacks
+        #   b) 1 callback that accesses the time-dependent Hamiltonian
+        #   c) 2 callbacks where one access the Hamiltonian and one doesn't
+
+        if num_callbacks > 0 and (dop or linop):
+            # should implement this at some point
+            return 
         L = 6
         T = 20
 
@@ -317,13 +328,40 @@ class TestEvolution:
         else:
             p0 = gs1
 
-        evo = qu.Evolution(p0, ham, progbar=True)
+        if num_callbacks == 0:
+            evo = qu.Evolution(p0, ham, progbar=True)
+        else:
+            def gs_overlap(t, pt, H):
+                evals, evecs = eigs_scipy(H(t), k=1, which='SA')
+                return np.abs(qu.dot(pt.T, qu.qu(evecs[:,0])))**2
+
+            if num_callbacks == 1:
+                compute = gs_overlap
+            if num_callbacks == 2:
+                def norm(t, pt):
+                    return qu.dot(pt.T, pt)
+                compute = {'norm' : norm, 'gs_overlap' : gs_overlap} 
+            evo = qu.Evolution(p0, ham, compute=compute, progbar=True)
+            
         evo.update_to(T)
 
         # final state should now overlap much more with second hamiltonian GS
         assert qu.fidelity(evo.pt, gs1) < 0.5
         assert qu.fidelity(evo.pt, gs2) > 0.99
 
+        if num_callbacks == 1:
+            gs_overlap_results = evo.results
+            # check that we stayed in the ground state the whole time
+            assert ((np.array(gs_overlap_results) - 1.0) < 1e-3).all()
+
+        if num_callbacks == 2:
+            norm_results = evo.results['norm']
+            gs_overlap_results = evo.results['gs_overlap']
+            # check that we stayed normalized the whole time
+            assert ((np.array(norm_results) - 1.0) < 1e-3).all()
+            # check that we stayed in the ground state the whole time
+            assert ((np.array(gs_overlap_results) - 1.0) < 1e-3).all()
+        
     def test_evo_at_times(self):
         ham = qu.ham_heis(2, cyclic=False)
         p0 = qu.up() & qu.down()
@@ -370,20 +408,28 @@ class TestEvolution:
         def some_other_quantity(_, pt):
             return qu.logneg(pt)
 
+        # check that hamiltonian gets accepted without error for all the methods
+        def some_other_quantity_accepting_ham(t, pt, H):
+            return qu.logneg(pt)
+        
         evo = qu.Evolution(p0, ham, method=method,
                            compute={'t': some_quantity,
-                                    'logneg': some_other_quantity})
+                                    'logneg': some_other_quantity,
+                                    'logneg_ham': some_other_quantity_accepting_ham})
+
         manual_lns = []
         for pt in evo.at_times(np.linspace(0, 1, 6)):
             manual_lns.append(qu.logneg(pt))
         ts = evo.results['t']
         lns = evo.results['logneg']
+        lns_ham = evo.results['logneg_ham']
         assert len(lns) >= len(manual_lns)
         # check a specific value of logneg at t=0.8 was computed automatically
         checked = False
-        for t, ln in zip(ts, lns):
+        for t, ln, ln_ham in zip(ts, lns, lns_ham):
             if abs(t - 0.8) < 1e-12:
                 assert abs(ln - manual_lns[4]) < 1e-12
+                assert ln == ln_ham # check that accepting hamiltonian didn't mess it up
                 checked = True
         assert checked
 


### PR DESCRIPTION
- convenient to use solved system in callbacks
- if hamiltonian is time-dependent, it will be cached
  and can be used for free by callbacks

Some repeated code in _setup_callbacks factored out in the process. Existing tests extended to cover these changes.
