### PR TITLE
evo: allow early stopping for integration

### DIFF
--- a/tests/test_evo.py
+++ b/tests/test_evo.py
@@ -302,10 +302,6 @@ class TestEvolution:
             # should implement this at some point
             return
 
-        if use_int_stop and dop:
-            # should implement this at some point
-            return
-
         L = 6
         T = 20
 

--- a/tests/test_evo.py
+++ b/tests/test_evo.py
@@ -420,6 +420,13 @@ class TestEvolution:
         sim.update_to(trc)
         assert sim.t == trc  # make sure it didn't stop early
 
+        # check that TypeError not related to argument count gets properly
+        #   raised
+        with raises(TypeError):
+            sim = qu.Evolution(p0, ham, method='integrate',
+                               int_stop=7)
+            sim.update_to(trc)
+
     def test_evo_at_times(self):
         ham = qu.ham_heis(2, cyclic=False)
         p0 = qu.up() & qu.down()


### PR DESCRIPTION
also extend test to cover this

This is a small PR just to give access to the early-stopping mechanism of the underlying SciPy ode solver (depending on the output of solout)