### PR TITLE
added an 'unfuse' method

### DIFF
--- a/quimb/tensor/tensor_core.py
+++ b/quimb/tensor/tensor_core.py
@@ -1408,7 +1408,7 @@ class Tensor(object):
 
         # create new tensor with new + remaining indices
         #     + updated 'left' marked indices assuming all unfused left inds
-        #       remain left marked
+        #       remain 'left' marked
         t.modify(data=reshape(t.data, new_dims),
                  inds=new_inds, left_inds=new_left_inds)
 

--- a/quimb/tensor/tensor_core.py
+++ b/quimb/tensor/tensor_core.py
@@ -1356,7 +1356,7 @@ class Tensor(object):
 
     fuse_ = functools.partialmethod(fuse, inplace=True)
 
-    def unfuse(self, fuse_map, shape_map, inplace=False):
+    def unfuse(self, unfuse_map, shape_map, inplace=False):
         """Reshape single indices into groups of multiple.
 
         Parameters
@@ -1379,10 +1379,10 @@ class Tensor(object):
         """
         t = self if inplace else self.copy()
 
-        if isinstance(fuse_map, dict):
-            old_inds, new_unfused_inds = zip(*fuse_map.items())
+        if isinstance(unfuse_map, dict):
+            old_inds, new_unfused_inds = zip(*unfuse_map.items())
         else:
-            old_inds, new_unfused_inds = zip(*fuse_map)
+            old_inds, new_unfused_inds = zip(*unfuse_map)
 
         # for each set of fused dims, group into product, then add remaining
         new_inds = [[i] for i in t.inds]

--- a/quimb/tensor/tensor_core.py
+++ b/quimb/tensor/tensor_core.py
@@ -21,10 +21,10 @@ import opt_einsum as oe
 import scipy.sparse.linalg as spla
 from autoray import do, conj, reshape, transpose
 
-# from ..core import qarray, prod, realify_scalar, vdot, common_type
-# from ..utils import check_opt, functions_equal
-# from ..gen.rand import randn, seed_rand
-# from . import decomp
+from ..core import qarray, prod, realify_scalar, vdot, common_type
+from ..utils import check_opt, functions_equal
+from ..gen.rand import randn, seed_rand
+from . import decomp
 from .array_ops import (iscomplex, norm_fro, unitize, ndim, asarray, PArray,
                         find_diag_axes, find_antidiag_axes, find_columns)
 

--- a/quimb/tensor/tensor_core.py
+++ b/quimb/tensor/tensor_core.py
@@ -1357,25 +1357,25 @@ class Tensor(object):
     fuse_ = functools.partialmethod(fuse, inplace=True)
 
     def unfuse(self, unfuse_map, shape_map, inplace=False):
-        """Reshape single indices into groups of multiple.
+        """Reshape single indices into groups of multiple indices
 
         Parameters
         ----------
-        fuse_map : dict_like or sequence of tuples.
+        unfuse_map : dict_like or sequence of tuples.
             Mapping like: ``{existing_ind: sequence of new inds, ...}`` or an
             ordered mapping like ``[(old_ind_1, new_inds_1), ...]`` in which
             case the output tensor's new inds will be ordered. In both cases
-            the new indices are created at the old index's position of the 
-            tensor's shape.
+            the new indices are created at the old index's position of the
+            tensor's shape
 
         shape_map : dict_like or sequence of tuples
             Mapping like: ``{old_ind: new_ind_sizes, ...}`` or an
-            ordered mapping like ``[(old_ind_1, new_ind_sizes_1), ...]`` .
+            ordered mapping like ``[(old_ind_1, new_ind_sizes_1), ...]``.
 
         Returns
         -------
         Tensor
-            The transposed, reshaped and re-labeled tensor.
+            The transposed, reshaped and re-labeled tensor
         """
         t = self if inplace else self.copy()
 
@@ -1396,18 +1396,14 @@ class Tensor(object):
         new_inds = tuple(itertools.chain(*new_inds))
         new_dims = tuple(itertools.chain(*new_dims))
 
-        if t.left_inds is not None:
-            new_left_inds = [[i] for i in t.left_inds]
-            for ix in range(len(old_inds)):
+        try:
+            new_left_inds = []
+            for ix in t.left_inds:
                 try:
-                    ind_pos = t.left_inds.index(old_inds[ix])
-                    new_left_inds[ind_pos] = new_unfused_inds[ix]
-                except(ValueError):
-                    pass
-
-            # flatten new_left_inds
-            new_left_inds = tuple(itertools.chain(*new_left_inds))
-        else:
+                    new_left_inds.extend(unfuse_map[ix])
+                except KeyError:
+                    new_left_inds.append(ix)
+        except TypeError:
             new_left_inds = None
 
         # create new tensor with new + remaining indices

--- a/tests/test_tensor/test_tensor_core.py
+++ b/tests/test_tensor/test_tensor_core.py
@@ -224,6 +224,27 @@ class TestBasicTensorOperations:
         assert set(b.inds) == {'ket', 'bra'}
         assert b.tags == {'blue'}
 
+    def test_unfuse(self):
+        a = Tensor(np.random.rand(2, 3, 4, 5), 'abcd', tags={'blue'})
+        b = a.fuse({'bra': ['a', 'c'], 'ket': 'bd'})
+
+        c = b.unfuse({'bra': ['a','c'], 'ket': 'bd'}, {'bra':[2,4], 'ket':[3,5]})
+        assert set(c.shape) == {2,3,4,5}
+        assert set(c.inds) == {'a','b','c','d'}
+        assert c.left_inds == b.left_inds
+        assert np.allclose( c.data.reshape(8,15) , b.data )
+
+        b.modify(left_inds=['ket'])
+        c = b.unfuse({'ket': 'bd'}, {'ket':[5,3]})
+        assert set(c.shape) == {3, 5, 8}
+        assert set(c.inds) == {'b','d','bra'}
+        assert c.tags == {'blue'}
+        assert set(c.left_inds) == {'b','d'}
+
+        b.modify(left_inds=['bra'])
+        c = b.unfuse({'ket': 'bd'}, {'ket':[5,3]})
+        assert set(c.left_inds) == {'bra'}
+
     def test_fuse_leftover(self):
         a = Tensor(np.random.rand(2, 3, 4, 5, 2, 2), 'abcdef', tags={'blue'})
         b = a.fuse({'bra': 'ac', 'ket': 'bd'})


### PR DESCRIPTION
added an 'unfuse' method that changes the shape of specified inds.  Positions of new inds group are in the position of the old ind.  Ordering and shape of within new inds group is specified in the input parameters 'unfuse_map' and 'shape_map'.