### PR TITLE
fix TypeError in compute_marginal function

### DIFF
--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -1839,7 +1839,7 @@ class Circuit:
             p_marginal = p_marginal**2
 
         if fix is not None:
-            p_marginal /= nfact
+            p_marginal = p_marginal / nfact
 
         return p_marginal
 


### PR DESCRIPTION
This is a fix for issue #97.  It prevents TypeError when sampling random quantum circuits.
# Test
This fix was tested with 3 random quantum circuits.  Before this fix, the problem mentioned in #97 showed up in these circuits.
1. 72-qubit, depth=6
2. 80-qubit, depth=6
3. 90-qubit, depth=6
## P.S.
More circuits are tested after the this fix.  `sample` handled a 10x10-qubit, depth-10 case on RTX3090, while the program ran out of memory in 10x10-qubit, depth-20 case.