### PR TITLE
Generate DocSet using doc2dash

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
+DOC2DASH      = doc2dash
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -113,7 +114,7 @@ docset:
 	$(DOC2DASH) --name quimb --icon _static/quimb_logo.png \
 	    --index-page index.html --online-redirect-url \
 		https://quimb.readthedocs.io/ --destination $(BUILDDIR) \
-		_build/html-nobars/
+		_build/html/
 	@echo "Build finished; the DocSet file is in $(BUILDDIR)."
 	@echo "Rebuild the html documentation to use it"
 	@echo "# make clean"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -57,6 +57,11 @@ html:
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
+html-docset:
+	$(SPHINXBUILD) -b html -t docset $(ALLSPHINXOPTS) $(BUILDDIR)/html-docset
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html-docset."
+
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
@@ -109,16 +114,12 @@ devhelp:
 	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/quimb"
 	@echo "# devhelp"
 
-docset:
-	make html SPHINXOPTS="-t nobars"
+docset: html-docset
 	$(DOC2DASH) --name quimb --icon _static/quimb_logo.png \
 	    --index-page index.html --online-redirect-url \
 		https://quimb.readthedocs.io/ --destination $(BUILDDIR) \
-		_build/html/
-	@echo "Build finished; the DocSet file is in $(BUILDDIR)."
-	@echo "Rebuild the html documentation to use it"
-	@echo "# make clean"
-	@echo "# make html"
+		_build/html-docset/
+	@echo "Build finished; the DocSet file is in $(BUILDDIR)/quimb.docset."
 
 epub:
 	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -108,6 +108,17 @@ devhelp:
 	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/quimb"
 	@echo "# devhelp"
 
+docset:
+	make html SPHINXOPTS="-t nobars"
+	$(DOC2DASH) --name quimb --icon _static/quimb_logo.png \
+	    --index-page index.html --online-redirect-url \
+		https://quimb.readthedocs.io/ --destination $(BUILDDIR) \
+		_build/html-nobars/
+	@echo "Build finished; the DocSet file is in $(BUILDDIR)."
+	@echo "Rebuild the html documentation to use it"
+	@echo "# make clean"
+	@echo "# make html"
+
 epub:
 	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	@echo

--- a/docs/_static/docset.css
+++ b/docs/_static/docset.css
@@ -1,0 +1,3 @@
+#site-navigation, .topbar {
+	display: none;
+}

--- a/docs/_static/docset.css
+++ b/docs/_static/docset.css
@@ -5,3 +5,8 @@
 .container-xl {
 	max-width: max-content;
 }
+
+.col-md-9 {
+	max-width: 100%;
+	flex: 0 0 100%;
+}

--- a/docs/_static/docset.css
+++ b/docs/_static/docset.css
@@ -1,3 +1,7 @@
 #site-navigation, .topbar {
 	display: none;
 }
+
+.container-xl {
+	max-width: max-content;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,7 +176,7 @@ def setup(app):
     app.add_css_file("my-styles.css")
 
     # Hide site-navigation sidebar and topbar. Used for DocSet generation.
-    if tags.has("nobars"):
+    if tags.has("docset"):
         app.add_css_file("docset.css")
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,6 +175,10 @@ html_static_path = ['_static']
 def setup(app):
     app.add_css_file("my-styles.css")
 
+    # Hide site-navigation sidebar and topbar. Used for DocSet generation.
+    if tags.has("nobars"):
+        app.add_css_file("docset.css")
+
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/develop.rst
+++ b/docs/develop.rst
@@ -43,6 +43,12 @@ Building the DocSet requires `doc2dash >= 2.4.1 <https://github.com/hynek/doc2da
 2. Run ``make docset`` in the ``quimb/docs`` folder.
 3. Open the file ``quimb/docs/_build/quimb.docset`` to load it to Dash.
 
+Afterwards, in order to update the Dash repository with a the DocSet after a new release:
+
+1. Clone the `Dash-User-Contributions <https://github.com/Kapeli/Dash-User-Contributions>`_.
+2. Go to `docsets/quimb`, create a new directory with the version name inside the `versions` dir and copy there the generated DocSet.
+3. Edit the `docset.json`: update the `"version"` and add a new element below `"specific_versions"`.
+4. Commit and create a new Pull Request.
 
 Minting a Release
 =================

--- a/docs/develop.rst
+++ b/docs/develop.rst
@@ -34,6 +34,15 @@ Building the docs requires `sphinx <http://www.sphinx-doc.org/en/stable/>`_, `sp
 2. Run ``make html`` (``make.bat html`` on windows) in the ``quimb/docs`` folder.
 3. Launch the page: ``quimb/docs/_build/html/index.html``.
 
+Building the DocSet
+-------------------
+
+Building the DocSet requires `doc2dash >= 2.4.1 <https://github.com/hynek/doc2dash>`_.
+
+1. To start from scratch, remove ``quimb/docs/_autosummary`` and ``quimb/docs/_build``.
+2. Run ``make docset`` in the ``quimb/docs`` folder.
+3. Open the file ``quimb/docs/_build/quimb.docset`` to load it to Dash.
+
 
 Minting a Release
 =================

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
             'ipython>=7.0',
             'autoray>=0.2.0',
             'opt_einsum>=3.2',
+            'doc2dash>=2.5.1',
         ],
     },
     scripts=['bin/quimb-mpi-python'],

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
             'ipython>=7.0',
             'autoray>=0.2.0',
             'opt_einsum>=3.2',
-            'doc2dash>=2.5.1',
+            'doc2dash>=2.4.1',
         ],
     },
     scripts=['bin/quimb-mpi-python'],


### PR DESCRIPTION
I added some instructions for automatizing the DocSet generation, which is used in documentation apps like Dash and Zeal.
It depends on `doc2dash >= 2.4.1` which should be soon released and it fixed a problem I had when using `doc2dash` with `quimb`.

Should I add `doc2dash >= 2.4.1` as a dependency for the `docs` extra requirements?

By the way, the site-location sidebar and the topbar unnecessarily take a significant amount of space in Dash, so I hide them with some CSS injection which I trigger with a `nobars` tag inside the `conf.py`:

https://github.com/mofeing/quimb/blob/9100da58321143532b27a8640107dff1dbdc0359/docs/conf.py#L178-L180

Thus, the `html` target has to be generated with the `-t nobars` flag. If you want to use the `html` documentation, the user has to rebuild it again. I added a note in the Makefile but I dunno if its something you like.