### PR TITLE
Fix docstring regarding `fit_strategy` parameter for `FullUpdate` class.

### DIFF
--- a/quimb/tensor/tensor_2d_tebd.py
+++ b/quimb/tensor/tensor_2d_tebd.py
@@ -953,11 +953,11 @@ class FullUpdate(TEBD2D):
         that boolean evaluates to ``True`` then terminal the evolution.
     progbar : boolean, optional
         Whether to show a live progress bar during the evolution.
-    fit_strategy : {'als', 'autodiff'}, optional
+    fit_strategy : {'als', 'autodiff-fidelity'}, optional
         Core method used to fit the gate application.
 
             * ``'als'``: alternating least squares
-            * ``'autodiff'``: local fidelity using autodiff
+            * ``'autodiff-fidelity'``: local fidelity using autodiff
 
     fit_opts : dict, optional
         Advanced options for the gate application fitting functions. Defaults


### PR DESCRIPTION
The `fit_strategy` parameter should be set to `autodiff-fidelity` instead of `autodiff` when trying to use an autodiff backend instead of ALS.