### PR TITLE
Ignore Python related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+[.]venv
+.python-version
+__pypackages__
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION
This commit tells Git to ignore some extra Python-related files:
- `[.]venv` is a usual name for virtualenvs
- `.python-version` is a byproduct of [pyenv](https://github.com/pyenv/pyenv)
- `__pypackages__` is used by [PEP 582](https://peps.python.org/pep-0582/) implementing tools, which expects to give a standard name to local virtualenvs (still in draft, but some tools start using it)
