### PR TITLE
Fix `parse_constant_arg` for lists, tuples of `TensorNetwork`s

### DIFF
--- a/quimb/tensor/optimize.py
+++ b/quimb/tensor/optimize.py
@@ -853,10 +853,10 @@ def parse_constant_arg(arg, to_constant):
         return valmap(to_constant, arg)
 
     if isinstance(arg, list):
-        return list(map(to_constant, arg))
+        return list(parse_constant_arg(i, to_constant) for i in arg)
 
     if isinstance(arg, tuple):
-        return tuple(map(to_constant, arg))
+        return tuple(parse_constant_arg(i, to_constant) for i in arg)
 
     # assume ``arg`` is a raw array
     return to_constant(arg)

--- a/quimb/tensor/optimize.py
+++ b/quimb/tensor/optimize.py
@@ -850,7 +850,7 @@ def parse_constant_arg(arg, to_constant):
         return constant_t(arg, to_constant)
 
     if isinstance(arg, dict):
-        return valmap(to_constant, arg)
+        return valmap(lambda i: parse_constant_arg(i, to_constant), arg)
 
     if isinstance(arg, list):
         return list(parse_constant_arg(i, to_constant) for i in arg)


### PR DESCRIPTION
I'm trying to optimize a `TensorNetwork` with a list of `TensorNetwork`s as `loss_constant`, but it fails to parse them to constants.

The problem is that `parse_constant_arg` expects only a container of arrays (i.e. a `TensorNetwork`, a `Tensor`, a `list`/`tuple`/`dict` of arrays, or an array) and does not descend recursively.

This PR should fix it while keeping previous functionality intact.