### PR TITLE
Fix deprecation warnings

### DIFF
--- a/quimb/linalg/approx_spectral.py
+++ b/quimb/linalg/approx_spectral.py
@@ -8,7 +8,7 @@ import warnings
 
 import numpy as np
 import scipy.linalg as scla
-from scipy.ndimage.filters import uniform_filter1d
+from scipy.ndimage import uniform_filter1d
 
 from ..core import ptr, prod, vdot, njit, dot, subtract_update_, divide_update_
 from ..utils import int2tup, find_library, raise_cant_find_library_function

--- a/quimb/tensor/tensor_builder.py
+++ b/quimb/tensor/tensor_builder.py
@@ -821,7 +821,7 @@ def HTN_CP_operator_from_products(
     tags_all=None,
     bond_ind=None,
 ):
-    """Construct a CP form hyper tensor network of the sum of matrix strings:
+    r"""Construct a CP form hyper tensor network of the sum of matrix strings:
 
     .. math::
 


### PR DESCRIPTION
Fixed following deprecation warnings:

```
quimb/linalg/approx_spectral.py:11
  /home/runner/work/quimb/quimb/quimb/linalg/approx_spectral.py:11: DeprecationWarning: Please use `uniform_filter1d` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
    from scipy.ndimage.filters import uniform_filter1d
```

```
quimb/tensor/tensor_builder.py:824
  /home/runner/work/quimb/quimb/quimb/tensor/tensor_builder.py:824: DeprecationWarning: invalid escape sequence '\s'
    """Construct a CP form hyper tensor network of the sum of matrix strings:
```