### PR TITLE
Fix empty lines in dimacs

### DIFF
--- a/quimb/tensor/tensor_builder.py
+++ b/quimb/tensor/tensor_builder.py
@@ -2758,6 +2758,10 @@ def cnf_file_parse(fname):
     with open(fname, "r") as f:
         for line in f:
             args = line.split()
+            
+            # ignore empty lines, other comments and info line
+            if (not args) or (args == ["0"]) or (args[0][0] in "c%"):
+                continue
 
             # global info, just record
             if args[0] == "p":
@@ -2788,10 +2792,6 @@ def cnf_file_parse(fname):
                     continue
 
                 weights[int(sgn_var)] = float(w)
-                continue
-
-            # ignore empty lines, other comments and info line
-            if (not args) or (args == ["0"]) or (args[0][0] in "c%"):
                 continue
 
             # clause tensor, drop last '0' (endline marker) and empty strings


### PR DESCRIPTION
Encountered a bug where `.cnf` files couldn't be loaded if they contain empty lines (see below). 
Fixed by moving the empty line check up.

```
  File ".../quimb/tensor/tensor_builder.py", line 2607, in cnf_file_parse
    if args[0] == "p":
IndexError: list index out of range
```