### PR TITLE
 apply_gate_raw: fix optional argument bug

### DIFF
--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -1606,7 +1606,7 @@ class Circuit:
         """Apply the raw array ``U`` as a gate on qubits in ``where``. It will
         be assumed to be unitary for the sake of computing reverse lightcones.
         """
-        gate = Gate.from_raw(U, where, gate_round)
+        gate = Gate.from_raw(U, where, round=gate_round)
         self._apply_gate(gate, **gate_opts)
 
     def apply_gates(self, gates, **gate_opts):


### PR DESCRIPTION
In the method `apply_gate_raw` of the class `Circuit`, the optional argument `gate_round` was input as a positional argument to the method `from_raw`. This resulted in a conflict with the positional argument `control`. Fixed by adding the parameter `gate_round` as a positional argument in `from_raw`.