### PR TITLE
Bugfix: SVD fallback exception from numba compiled function

### DIFF
--- a/quimb/tensor/decomp.py
+++ b/quimb/tensor/decomp.py
@@ -343,7 +343,7 @@ def svd_truncated_numpy(
         return svd_truncated_numba(
             x, cutoff, cutoff_mode, max_bond, absorb, renorm
         )
-    except (np.linalg.LinAlgError, ValueError) as e:  # pragma: no cover
+    except ValueError as e:  # pragma: no cover
         warnings.warn(f"Got: {e}, falling back to scipy gesvd driver.")
         U, s, VH = scla.svd(x, full_matrices=False, lapack_driver="gesvd")
         return _trim_and_renorm_svd_result_numba(

--- a/quimb/tensor/decomp.py
+++ b/quimb/tensor/decomp.py
@@ -343,7 +343,7 @@ def svd_truncated_numpy(
         return svd_truncated_numba(
             x, cutoff, cutoff_mode, max_bond, absorb, renorm
         )
-    except np.linalg.LinAlgError as e:  # pragma: no cover
+    except (np.linalg.LinAlgError, ValueError) as e:  # pragma: no cover
         warnings.warn(f"Got: {e}, falling back to scipy gesvd driver.")
         U, s, VH = scla.svd(x, full_matrices=False, lapack_driver="gesvd")
         return _trim_and_renorm_svd_result_numba(


### PR DESCRIPTION
Details:
PennyLane has a new device ([`default.tensor`](https://github.com/PennyLaneAI/pennylane/blob/bec5bb0d8baa99a9e10fcce867a0160188ec6bdc/pennylane/devices/default_tensor.py#L147)) which can use quimb under the hood for the MPS and TN implementations. Currently, we observed a failure mode with a given circuit with the MPS backend:

```
import pennylane as qml

wires=62
layers=4
dev = qml.device("default.tensor", wires=wires)

@qml.qnode(dev)
def circuit():
    for l in range(layers):
        for i in range(wires):
            qml.RX(0.1234,i)
            qml.CNOT(wires=[i,(i+1)%wires])
        
    return qml.expval(qml.PauliZ(0))

print(circuit())
```

For the above, and when setting OMP_NUM_THREADS to any value except that exact physical cores, we see the GESDD SVD method fail to converge (a [known issue](https://github.com/OpenMathLib/OpenBLAS/issues/3044) for others with LAPACK GESDD calls). This should be caught by the `quimb/tensor/decomp.py::svd_truncated_numpy` function, which checks for a numpy-raised `LinAlgError`, and if so falls back to the GESVD implementation. However, when numba compiles the `svd_truncated_numba` function, the raised error is no longer a `LinAlgError`, but the more general [`ValueError`](https://github.com/numba/numba/blob/fb1d52b988d308852a7023132eabaee8c7a750dd/numba/np/linalg.py#L955), causing the fallback to fail.

This PR replaces the `LinAlgError` check with a `ValueError` check, which should catch both cases due to the error hierarchy 
(https://numpy.org/doc/stable/reference/generated/numpy.linalg.LinAlgError.html).

---

With the above change, we are successfully able to run our given circuit. If keeping both error types is preferred, I'll be happy to readd the LinAlgError type back in.