### PR TITLE
Added an 'identity' tensor splitting option

### DIFF
--- a/quimb/tensor/decomp.py
+++ b/quimb/tensor/decomp.py
@@ -186,6 +186,19 @@ def _trim_and_renorm_svd_result(
 
 
 @compose
+def identity(x, backend=None, **kwargs):
+    """
+    No-op "decomposition" that leaves the input unchanged. Can be useful to quickly build a tensor network representing a given tensor "as is".
+    """
+
+    with backend_like(backend):
+        if x.shape[0] < x.shape[1]:
+            return do("eye", x.shape[0]), do("ones", x.shape[0]), x
+        else:
+            return x, do("ones", x.shape[1]), do("eye", x.shape[1])
+
+
+@compose
 def svd_truncated(
     x,
     cutoff=-1.0,

--- a/quimb/tensor/tensor_core.py
+++ b/quimb/tensor/tensor_core.py
@@ -325,6 +325,7 @@ def rand_uuid(base=""):
 
 _VALID_SPLIT_GET = {None, "arrays", "tensors", "values"}
 _SPLIT_FNS = {
+    "identity": decomp.identity,
     "svd": decomp.svd_truncated,
     "eig": decomp.svd_via_eig_truncated,
     "lu": decomp.lu_truncated,


### PR DESCRIPTION
This PR adds an "identity" tensor split operation that does nothing, i.e. sets the identity matrix as either the left or the right split. One use is creating an MPS network from a dense tensor in very little time and zero error.

(forgive me if there's a way to do this already -- I didn't find it)