### PR TITLE
Relax equality tolerance for `float32` values

### DIFF
--- a/tests/test_tensor/test_tensor_core.py
+++ b/tests/test_tensor/test_tensor_core.py
@@ -1650,7 +1650,8 @@ class TestTensorNetwork:
             assert psi.H @ psi == pytest.approx(x_exp, rel=1e-4)
         else:
             assert all(n1 == pytest.approx(value) for n1 in enorms)
-            assert (psi.H @ psi) == pytest.approx(x_exp)
+            rel = 1e-5 if dtype == "float32" else None
+            assert (psi.H @ psi) == pytest.approx(x_exp, rel=rel)
 
     @pytest.mark.parametrize("append", [None, "*"])
     def test_mangle_inner(self, append):


### PR DESCRIPTION
`TestTensorNetwork.test_equalize_norms[42-float32]` fails when running with Python 3.13.x and the latest release.

Use a relative tolerance of `1e-5` instead of the default `1e-6` for the single precision case to avoid the test failure.

Fixes #328