### PR TITLE
fix contract_ind passing inplace kwarg to cotengra

### DIFF
--- a/quimb/tensor/tensor_core.py
+++ b/quimb/tensor/tensor_core.py
@@ -5769,6 +5769,7 @@ class TensorNetwork:
         contract_opts
             Supplied to :func:`~quimb.tensor.tensor_core.tensor_contract`.
         """
+        contract_opts.pop("inplace", None)
         tids = tuple(self._get_tids_from_inds(ind))
         output_inds = self.compute_contracted_inds(
             *tids, output_inds=output_inds

--- a/tests/test_tensor/test_tensor_core.py
+++ b/tests/test_tensor/test_tensor_core.py
@@ -1100,6 +1100,14 @@ class TestTensorNetwork:
         assert tn.contraction_width() == 6
         assert tn.contraction_cost() == 2 * 8**3
 
+    def test_contract_ind_with_inplace_kwarg(self):
+        a = rand_tensor([2, 3], "ab")
+        b = rand_tensor([3, 4], "bc")
+        tn = a & b
+        # inplace=False should not raise a TypeError when passed to contract_ind
+        tn.contract_ind("b", inplace=False)
+        assert tn.num_indices == 2
+
     def test_contract_to_dense_reduced_factor(self):
         tn = qtn.PEPS.rand(2, 2, 2)
         left_inds = ["k0,0", "k0,1"]


### PR DESCRIPTION
`TensorNetwork.contract_ind` accepted `**contract_opts` and forwarded them directly to `tensor_contract`, causing an `inplace` kwarg to reach cotengra's `_build_expression`, which does not accept it and raises a `TypeError`. The fix adds a single `contract_opts.pop("inplace", None)` line at the top of `contract_ind` before the opts are passed down. To verify, call `tn.contract_ind(ind, inplace=False)` on any two-tensor network sharing an index and confirm no `TypeError` is raised; the new test `test_contract_ind_with_inplace_kwarg` covers this case.

Fixes #303