### PR TITLE
Add open qasm 3 support (Issue #256)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Release notes for `quimb`.
 - [`TensorNetwork.gauge_all_simple`](quimb.tensor.tensor_core.TensorNetwork.gauge_all_simple): add a ``fuse_multibonds`` option for updating gauges while preserving multi-index bonds, supported by explicit bond-index selection in [`tensor_compress_bond`](quimb.tensor.tensor_core.tensor_compress_bond).
 - add [`LatticeBondMap`](quimb.tensor.tnag.core.LatticeBondMap): helper for consistently assigning lattice bond indices across ordinary and periodic boundaries, use it in PEPS, PEPO, PEPS3D, scalar 2D/3D lattice tensor-network construction, and classical Ising tensor-network construction.
 - [`eigh_truncated`](quimb.tensor.decomp.eigh_truncated): add a ``shift`` option for optional diagonal regularization.
-- [`Circuit.from_openqasm3_str`](quimb.tensor.circuit.Circuit.from_openqasm3_str), [`Circuit.from_openqasm3_file`](quimb.tensor.circuit.Circuit.from_openqasm3_file), and [`Circuit.from_openqasm3_url`](quimb.tensor.circuit.Circuit.from_openqasm3_url): add dependency-free OpenQASM 3 parsing with custom gates, register broadcasting, and symbolic input tracking.
+- [`Circuit.from_openqasm3_str`](quimb.tensor.circuit.Circuit.from_openqasm3_str), [`Circuit.from_openqasm3_file`](quimb.tensor.circuit.Circuit.from_openqasm3_file), and [`Circuit.from_openqasm3_url`](quimb.tensor.circuit.Circuit.from_openqasm3_url): add OpenQASM 3 parsing with custom gates, register broadcasting, and symbolic input tracking.
 
 
 **Bug fixes:**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ Release notes for `quimb`.
 - [`TensorNetwork.gauge_all_simple`](quimb.tensor.tensor_core.TensorNetwork.gauge_all_simple): add a ``fuse_multibonds`` option for updating gauges while preserving multi-index bonds, supported by explicit bond-index selection in [`tensor_compress_bond`](quimb.tensor.tensor_core.tensor_compress_bond).
 - add [`LatticeBondMap`](quimb.tensor.tnag.core.LatticeBondMap): helper for consistently assigning lattice bond indices across ordinary and periodic boundaries, use it in PEPS, PEPO, PEPS3D, scalar 2D/3D lattice tensor-network construction, and classical Ising tensor-network construction.
 - [`eigh_truncated`](quimb.tensor.decomp.eigh_truncated): add a ``shift`` option for optional diagonal regularization.
+- [`Circuit.from_openqasm3_str`](quimb.tensor.circuit.Circuit.from_openqasm3_str), [`Circuit.from_openqasm3_file`](quimb.tensor.circuit.Circuit.from_openqasm3_file), and [`Circuit.from_openqasm3_url`](quimb.tensor.circuit.Circuit.from_openqasm3_url): add dependency-free OpenQASM 3 parsing with custom gates, register broadcasting, and symbolic input tracking.
 
 
 **Bug fixes:**

--- a/docs/index_tn.md
+++ b/docs/index_tn.md
@@ -11,6 +11,7 @@ tensor/tensor-optimization
 tensor/tensor-1d
 tensor/tensor-2d
 tensor/tensor-circuit
+tensor/tensor-openqasm
 tensor/tensor-circuit-mps
 tensor/tensor-design
 ```

--- a/docs/tensor/tensor-openqasm.md
+++ b/docs/tensor/tensor-openqasm.md
@@ -84,9 +84,20 @@ The imported circuit exposes:
 - `circ.named_param_names`: declared named parameter names
 - `circ.param_expressions`: symbolic expressions attached to parameterized gates
 
+Unbound named parameters are initialized to `nan`, and any gate parameters that
+depend on them are likewise initialized to `nan` until values are supplied.
+
 Named updates can be mixed with raw gate-index updates in the same
 `set_params(...)` call, for example `{"theta": 0.3, 5: (0.1, 0.2, 0.3)}`.
-Unknown names raise an error.
+Any expressions that still depend on
+unbound names remain `nan` until those names are set. Unknown names raise an
+error, and gate parameters managed by named expressions cannot be overridden
+directly via their integer gate indices.
+
+The same named-parameter mechanism can also be used outside OpenQASM import via
+[`Circuit.register_named_params`](quimb.tensor.circuit.Circuit.register_named_params),
+with expressions such as `cos(theta / 2)` attached to arbitrary parametrized
+gates.
 
 ## OpenQASM 2 compatibility
 

--- a/docs/tensor/tensor-openqasm.md
+++ b/docs/tensor/tensor-openqasm.md
@@ -1,0 +1,98 @@
+# Importing OpenQASM Circuits
+
+`quimb` supports importing both OpenQASM 2 and a practical subset of
+OpenQASM 3 into [`Circuit`](quimb.tensor.circuit.Circuit) objects.
+
+## OpenQASM 3 entry points
+
+Use the classmethods on [`Circuit`](quimb.tensor.circuit.Circuit):
+
+- [`Circuit.from_openqasm3_str`](quimb.tensor.circuit.Circuit.from_openqasm3_str)
+- [`Circuit.from_openqasm3_file`](quimb.tensor.circuit.Circuit.from_openqasm3_file)
+- [`Circuit.from_openqasm3_url`](quimb.tensor.circuit.Circuit.from_openqasm3_url)
+
+These parse the source and immediately build a circuit with the imported
+gates:
+
+```python
+import quimb.tensor as qtn
+
+qasm = """
+OPENQASM 3.0;
+include "stdgates.inc";
+
+qubit[2] q;
+h q[0];
+cx q[0], q[1];
+"""
+
+circ = qtn.Circuit.from_openqasm3_str(qasm)
+print(circ)
+```
+
+## Supported OpenQASM 3 subset
+
+The parser focuses on circuit input. It currently does not support the full QASM 3.0 language. Supported features include:
+
+- `qubit` declarations
+- `input` declarations for symbolic gate parameters
+- arithmetic expressions such as `pi / 2` or `theta / 2`
+- `const`, scalar classical declarations, and array declarations used in
+  parameter expressions
+- custom gate definitions, including nested custom gates
+- register broadcasting such as `h q;` or `cx q, r;`
+
+Ignored with warnings:
+
+- `measure`
+- `barrier`
+- `gphase`
+- plain `bit` declarations used only for classical measurement targets
+
+Unsupported constructs raise `NotImplementedError`, including:
+
+- `output` declarations
+- control flow such as `if`, `for`, and `while`
+- `reset`
+- calibration-related constructs
+
+## Symbolic inputs and rebinding
+
+OpenQASM 3 `input` declarations are preserved on the returned circuit so that
+named values can be bound later with [`Circuit.set_params`](quimb.tensor.circuit.Circuit.set_params):
+
+```python
+import quimb.tensor as qtn
+
+qasm = """
+OPENQASM 3.0;
+include "stdgates.inc";
+
+input float theta;
+qubit[1] q;
+rx(theta) q[0];
+"""
+
+circ = qtn.Circuit.from_openqasm3_str(qasm)
+circ.set_params({"theta": 0.3})
+```
+
+The imported circuit tracks:
+
+- `circ.qasm3_inputs`: declared input names
+- `circ.qasm3_symbols`: current symbolic or numeric values
+- `circ.qasm3_expressions`: symbolic expressions attached to parameterized gates
+
+All declared inputs must be supplied when binding by name, and unknown names
+raise an error.
+
+## OpenQASM 2 compatibility
+
+Equivalent OpenQASM 2 import helpers remain available:
+
+- [`Circuit.from_openqasm2_str`](quimb.tensor.circuit.Circuit.from_openqasm2_str)
+- [`Circuit.from_openqasm2_file`](quimb.tensor.circuit.Circuit.from_openqasm2_file)
+- [`Circuit.from_openqasm2_url`](quimb.tensor.circuit.Circuit.from_openqasm2_url)
+
+Where the same gate subset is used, the OpenQASM 2 and OpenQASM 3 import paths
+produce matching circuits.

--- a/docs/tensor/tensor-openqasm.md
+++ b/docs/tensor/tensor-openqasm.md
@@ -58,8 +58,9 @@ Unsupported constructs raise `NotImplementedError`, including:
 
 ## Symbolic inputs and rebinding
 
-OpenQASM 3 `input` declarations are preserved on the returned circuit so that
-named values can be bound later with [`Circuit.set_params`](quimb.tensor.circuit.Circuit.set_params):
+OpenQASM 3 `input` declarations are registered as named circuit parameters so
+that values can be bound later with
+[`Circuit.set_params`](quimb.tensor.circuit.Circuit.set_params):
 
 ```python
 import quimb.tensor as qtn
@@ -77,14 +78,15 @@ circ = qtn.Circuit.from_openqasm3_str(qasm)
 circ.set_params({"theta": 0.3})
 ```
 
-The imported circuit tracks:
+The imported circuit exposes:
 
-- `circ.qasm3_inputs`: declared input names
-- `circ.qasm3_symbols`: current symbolic or numeric values
-- `circ.qasm3_expressions`: symbolic expressions attached to parameterized gates
+- `circ.named_params`: current named parameter values
+- `circ.named_param_names`: declared named parameter names
+- `circ.param_expressions`: symbolic expressions attached to parameterized gates
 
-All declared inputs must be supplied when binding by name, and unknown names
-raise an error.
+Named updates can be mixed with raw gate-index updates in the same
+`set_params(...)` call, for example `{"theta": 0.3, 5: (0.1, 0.2, 0.3)}`.
+Unknown names raise an error.
 
 ## OpenQASM 2 compatibility
 

--- a/docs/tensor/tensor-openqasm.md
+++ b/docs/tensor/tensor-openqasm.md
@@ -89,15 +89,20 @@ depend on them are likewise initialized to `nan` until values are supplied.
 
 Named updates can be mixed with raw gate-index updates in the same
 `set_params(...)` call, for example `{"theta": 0.3, 5: (0.1, 0.2, 0.3)}`.
-Any expressions that still depend on
-unbound names remain `nan` until those names are set. Unknown names raise an
-error, and gate parameters managed by named expressions cannot be overridden
-directly via their integer gate indices.
+This round-trips with `get_params()`, which returns named parameters plus only
+those integer-indexed parametrized gates not managed by named expressions, and
+works with generic parameter-handling tools such as
+[`TNOptimizer`](quimb.tensor.optimize.TNOptimizer). Partial named updates are
+allowed: expressions that still depend on unbound names remain `nan` until
+those names are set. Unknown names raise an error, and expression-managed gates
+cannot be overridden directly via their integer gate indices.
 
 The same named-parameter mechanism can also be used outside OpenQASM import via
 [`Circuit.register_named_params`](quimb.tensor.circuit.Circuit.register_named_params),
-with expressions such as `cos(theta / 2)` attached to arbitrary parametrized
-gates.
+either by supplying a sequence of names or a mapping of initial values, with
+string expressions such as `cos(theta / 2)` or callables attached to arbitrary
+parametrized gates. String-keyed `set_params(...)` updates require such named
+parameters to have been registered first.
 
 ## OpenQASM 2 compatibility
 

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -159,7 +159,9 @@ def _openqasm_replace_tokens(s, replacements):
     if not replacements:
         return s
 
-    pattern = "|".join(sorted(map(re.escape, replacements), key=len, reverse=True))
+    pattern = "|".join(
+        sorted(map(re.escape, replacements), key=len, reverse=True)
+    )
     return re.sub(
         rf"(?<!\w)({pattern})(?!\w)",
         lambda match: replacements[match.group(1)],
@@ -610,13 +612,43 @@ def parse_openqasm2_url(url, **kwargs):
 
 
 def parse_openqasm3_str(contents):
-    """Parse the string contents of an OpenQASM 3.0 file.
+    """Parse an OpenQASM 3.0 program from a string.
 
     This parser is dependency free and supports a practical subset of
-    OpenQASM 3 for circuit import: qubit declarations, input declarations,
-    gate applications, simple custom gates, register broadcast, and arithmetic
-    expressions. Unsupported control flow and calibration constructs raise
-    ``NotImplementedError`` explicitly.
+    OpenQASM 3 for circuit import, including qubit declarations, input
+    declarations, arithmetic expressions, custom gates, and register
+    broadcasting.
+
+    Parameters
+    ----------
+    contents : str
+        The OpenQASM 3 source code to parse.
+
+    Returns
+    -------
+    dict
+        A dictionary describing the circuit with the following entries:
+
+        - ``"n"``: total number of qubits.
+        - ``"sitemap"``: mapping from OpenQASM qubit names to qubit indices.
+        - ``"gates"``: parsed sequence of :class:`Gate` objects.
+        - ``"n_gates"``: total number of parsed gates.
+        - ``"inputs"``: tuple of symbolic input names declared with
+          ``input``.
+        - ``"symbols"``: mapping of symbolic names to their current values or
+          symbolic placeholders.
+        - ``"expressions"``: mapping from gate indices to symbolic parameter
+          expressions requiring later binding.
+
+    Raises
+    ------
+    NotImplementedError
+        If the program uses unsupported OpenQASM 3 features such as control
+        flow, calibration blocks, output declarations, or unsupported
+        operations.
+    SyntaxError
+        If the source contains an instruction that does not match the
+        supported grammar subset.
     """
     rgxs = get_openqasm3_regexes()
     sitemap = {}
@@ -942,13 +974,41 @@ def parse_openqasm3_str(contents):
 
 
 def parse_openqasm3_file(fname, **kwargs):
-    """Parse an OpenQASM 3.0 file."""
+    """Parse an OpenQASM 3.0 file.
+
+    Parameters
+    ----------
+    fname : str or path-like
+        Path to the OpenQASM 3 file.
+    **kwargs
+        Forwarded to :func:`parse_openqasm3_str`.
+
+    Returns
+    -------
+    dict
+        The parsed circuit information returned by
+        :func:`parse_openqasm3_str`.
+    """
     with open(fname) as f:
         return parse_openqasm3_str(f.read(), **kwargs)
 
 
 def parse_openqasm3_url(url, **kwargs):
-    """Parse an OpenQASM 3.0 url."""
+    """Parse an OpenQASM 3.0 program from a URL.
+
+    Parameters
+    ----------
+    url : str
+        URL pointing to an OpenQASM 3 source file.
+    **kwargs
+        Forwarded to :func:`parse_openqasm3_str`.
+
+    Returns
+    -------
+    dict
+        The parsed circuit information returned by
+        :func:`parse_openqasm3_str`.
+    """
     from urllib import request
 
     return parse_openqasm3_str(request.urlopen(url).read().decode(), **kwargs)
@@ -2582,7 +2642,25 @@ class Circuit:
 
     @classmethod
     def from_openqasm3_str(cls, contents, progbar=False, **circuit_opts):
-        """Generate a ``Circuit`` instance from an OpenQASM 3.0 string."""
+        """Construct a circuit from an OpenQASM 3.0 string.
+
+        Parameters
+        ----------
+        contents : str
+            The OpenQASM 3 source code to parse.
+        progbar : bool, optional
+            Whether to show a progress bar while applying the parsed gates.
+        **circuit_opts
+            Options forwarded to the ``Circuit`` constructor.
+
+        Returns
+        -------
+        Circuit
+            A circuit populated with the parsed gates. If symbolic ``input``
+            declarations are present, the returned circuit tracks them via
+            ``qasm3_inputs``, ``qasm3_symbols``, and ``qasm3_expressions`` so
+            that :meth:`set_params` can bind named values later.
+        """
         info = parse_openqasm3_str(contents)
         qc = cls(info["n"], **circuit_opts)
         qc.apply_gates(info["gates"], progbar=progbar)
@@ -2593,7 +2671,22 @@ class Circuit:
 
     @classmethod
     def from_openqasm3_file(cls, fname, progbar=False, **circuit_opts):
-        """Generate a ``Circuit`` instance from an OpenQASM 3.0 file."""
+        """Construct a circuit from an OpenQASM 3.0 file.
+
+        Parameters
+        ----------
+        fname : str or path-like
+            Path to the OpenQASM 3 file.
+        progbar : bool, optional
+            Whether to show a progress bar while applying the parsed gates.
+        **circuit_opts
+            Options forwarded to the ``Circuit`` constructor.
+
+        Returns
+        -------
+        Circuit
+            The parsed circuit instance.
+        """
         info = parse_openqasm3_file(fname)
         qc = cls(info["n"], **circuit_opts)
         qc.apply_gates(info["gates"], progbar=progbar)
@@ -2604,7 +2697,22 @@ class Circuit:
 
     @classmethod
     def from_openqasm3_url(cls, url, progbar=False, **circuit_opts):
-        """Generate a ``Circuit`` instance from an OpenQASM 3.0 url."""
+        """Construct a circuit from an OpenQASM 3.0 URL.
+
+        Parameters
+        ----------
+        url : str
+            URL pointing to an OpenQASM 3 source file.
+        progbar : bool, optional
+            Whether to show a progress bar while applying the parsed gates.
+        **circuit_opts
+            Options forwarded to the ``Circuit`` constructor.
+
+        Returns
+        -------
+        Circuit
+            The parsed circuit instance.
+        """
         info = parse_openqasm3_url(url)
         qc = cls(info["n"], **circuit_opts)
         qc.apply_gates(info["gates"], progbar=progbar)

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -1,6 +1,8 @@
 """Tools for quantum circuit simulation using tensor networks."""
 
+import ast
 import cmath
+import copy
 import functools
 import itertools
 import math
@@ -10,7 +12,13 @@ import re
 import warnings
 
 import numpy as np
-from autoray import astype, backend_like, do, get_dtype_name, reshape
+from autoray import (
+    astype,
+    backend_like,
+    do,
+    get_dtype_name,
+    reshape,
+)
 
 import quimb as qu
 
@@ -160,6 +168,239 @@ def get_openqasm2_regexes():
         "gate_def": re.compile(r"^gate\s+"),
         "gate_sig": re.compile(r"^gate\s+(\w+)\s*(\((.+)\))?\s*(.*)"),
     }
+
+
+@functools.lru_cache(None)
+def get_openqasm3_regexes():
+    return {
+        "header": re.compile(
+            r"(OPENQASM\s+3(?:\.\d+)?;)"
+            r"|(include\s+\"(?:stdgates|qelib1)\.inc\";)"
+        ),
+        "comment": re.compile(r"^//"),
+        "comment_start": re.compile(r"/\*"),
+        "comment_end": re.compile(r"\*/"),
+        "qubit": re.compile(r"qubit(?:\s*\[(.+)\])?\s+(\w+);"),
+        "input": re.compile(r"input\s+\w+(?:\s*\[[^\]]+\])?\s+(\w+);"),
+        "output": re.compile(r"output\s+\w+(?:\s*\[[^\]]+\])?\s+(\w+);"),
+        "const": re.compile(
+            r"const\s+\w+(?:\s*\[[^\]]+\])?\s+(\w+)\s*=\s*(.+);"
+        ),
+        "classical_decl": re.compile(
+            r"(bit|bool|int|uint|float|angle|complex)(?:\s*\[[^\]]+\])?\s+"
+            r"(\w+)(?:\s*=\s*(.+))?;"
+        ),
+        "array_decl": re.compile(r"array\s*\[.*\]\s+(\w+)\s*=\s*(.+);"),
+        "assign": re.compile(r"(\w+)\s*=\s*(.+);"),
+        "ignore": re.compile(r"^(measure|barrier|gphase)\b"),
+        "error": re.compile(
+            r"^(reset|if|for|while|switch|box|delay|defcal|cal|extern|pragma"
+            r"|alias|return)\b"
+        ),
+        "gate_def": re.compile(r"^gate\s+"),
+        "gate_sig": re.compile(r"^gate\s+(\w+)\s*(?:\((.*?)\))?\s*(.*?)\s*$"),
+        "gate": re.compile(r"(\w+)\s*(?:\((.*)\))?\s*(.*);"),
+    }
+
+
+def _openqasm_split_top_level(s, sep=","):
+    if not s:
+        return []
+
+    parts = []
+    cur = []
+    depth_paren = 0
+    depth_brack = 0
+    depth_brace = 0
+
+    for c in s:
+        if c == "(":
+            depth_paren += 1
+        elif c == ")":
+            depth_paren -= 1
+        elif c == "[":
+            depth_brack += 1
+        elif c == "]":
+            depth_brack -= 1
+        elif c == "{":
+            depth_brace += 1
+        elif c == "}":
+            depth_brace -= 1
+
+        if (
+            c == sep
+            and depth_paren == 0
+            and depth_brack == 0
+            and depth_brace == 0
+        ):
+            parts.append("".join(cur).strip())
+            cur = []
+        else:
+            cur.append(c)
+
+    if cur:
+        parts.append("".join(cur).strip())
+
+    return [p for p in parts if p]
+
+
+def _openqasm_eval_expr(expr, env):
+    expr = expr.strip()
+    if not expr:
+        return None
+
+    tree = ast.parse(expr, mode="eval")
+
+    allowed_binary_ops = {
+        ast.Add: ("+", operator.add),
+        ast.Sub: ("-", operator.sub),
+        ast.Mult: ("*", operator.mul),
+        ast.Div: ("/", operator.truediv),
+        ast.FloorDiv: ("//", operator.floordiv),
+        ast.Mod: ("%", operator.mod),
+        ast.Pow: ("**", operator.pow),
+        ast.LShift: ("<<", operator.lshift),
+        ast.RShift: (">>", operator.rshift),
+        ast.BitAnd: ("&", operator.and_),
+        ast.BitXor: ("^", operator.xor),
+        ast.BitOr: ("|", operator.or_),
+    }
+    allowed_unary_ops = {
+        ast.USub: ("-", operator.neg),
+        ast.UAdd: ("+", operator.pos),
+        ast.Invert: ("~", operator.invert),
+        ast.Not: ("!", operator.not_),
+    }
+    allowed_fns = {
+        "sin": math.sin,
+        "cos": math.cos,
+        "tan": math.tan,
+        "asin": math.asin,
+        "acos": math.acos,
+        "atan": math.atan,
+        "exp": math.exp,
+        "ln": math.log,
+        "log": math.log,
+        "sqrt": math.sqrt,
+        "abs": abs,
+        "pow": pow,
+    }
+
+    def _to_expr_str(x):
+        if isinstance(x, str):
+            return x
+        return repr(x)
+
+    def _combine_symbolic(op, *xs):
+        if len(xs) == 1:
+            (x,) = xs
+            if op == "+":
+                return f"(+{_to_expr_str(x)})"
+            if op == "-":
+                return f"(-{_to_expr_str(x)})"
+            if op == "~":
+                return f"(~{_to_expr_str(x)})"
+            if op == "!":
+                return f"(!{_to_expr_str(x)})"
+        if op in {
+            "sin",
+            "cos",
+            "tan",
+            "asin",
+            "acos",
+            "atan",
+            "exp",
+            "ln",
+            "log",
+            "sqrt",
+            "abs",
+        }:
+            return f"{op}({', '.join(map(_to_expr_str, xs))})"
+        return f"({_to_expr_str(xs[0])} {op} {_to_expr_str(xs[1])})"
+
+    def _is_numeric(x):
+        return isinstance(x, numbers.Number)
+
+    allowed_compare_ops = {
+        ast.Eq: ("==", operator.eq),
+        ast.NotEq: ("!=", operator.ne),
+        ast.Lt: ("<", operator.lt),
+        ast.LtE: ("<=", operator.le),
+        ast.Gt: (">", operator.gt),
+        ast.GtE: (">=", operator.ge),
+    }
+
+    def _eval_node(node):
+        if isinstance(node, ast.Constant):
+            return node.value
+        if isinstance(node, ast.Name):
+            if node.id == "pi":
+                return math.pi
+            if node.id in env:
+                return env[node.id]
+            raise NotImplementedError(
+                f"Unknown OpenQASM 3 identifier: {node.id}"
+            )
+        if isinstance(node, ast.BinOp):
+            lhs = _eval_node(node.left)
+            rhs = _eval_node(node.right)
+            optype = type(node.op)
+            if optype not in allowed_binary_ops:
+                raise NotImplementedError(
+                    f"Unsupported OpenQASM 3 operator: {optype.__name__}"
+                )
+            op, fn = allowed_binary_ops[optype]
+            if _is_numeric(lhs) and _is_numeric(rhs):
+                return fn(lhs, rhs)
+            return _combine_symbolic(op, lhs, rhs)
+        if isinstance(node, ast.UnaryOp):
+            x = _eval_node(node.operand)
+            optype = type(node.op)
+            if optype not in allowed_unary_ops:
+                raise NotImplementedError(
+                    f"Unsupported OpenQASM 3 unary op: {optype.__name__}"
+                )
+            op, fn = allowed_unary_ops[optype]
+            if _is_numeric(x):
+                return fn(x)
+            return _combine_symbolic(op, x)
+        if isinstance(node, ast.Call):
+            if not isinstance(node.func, ast.Name):
+                raise NotImplementedError(
+                    "Unsupported OpenQASM 3 callable expression."
+                )
+            name = node.func.id
+            if name not in allowed_fns:
+                raise NotImplementedError(
+                    f"Unsupported OpenQASM 3 function: {name}"
+                )
+            args = [_eval_node(a) for a in node.args]
+            if all(_is_numeric(a) for a in args):
+                return allowed_fns[name](*args)
+            return _combine_symbolic(name, *args)
+        if isinstance(node, ast.Compare):
+            if len(node.ops) != 1 or len(node.comparators) != 1:
+                raise NotImplementedError(
+                    "Chained comparisons not supported in OpenQASM 3."
+                )
+            lhs = _eval_node(node.left)
+            rhs = _eval_node(node.comparators[0])
+            optype = type(node.ops[0])
+            if optype not in allowed_compare_ops:
+                raise NotImplementedError(
+                    f"Unsupported OpenQASM 3 compare op: {optype.__name__}"
+                )
+            op, fn = allowed_compare_ops[optype]
+            if _is_numeric(lhs) and _is_numeric(rhs):
+                return fn(lhs, rhs)
+            return _combine_symbolic(op, lhs, rhs)
+        if isinstance(node, ast.List):
+            return [_eval_node(x) for x in node.elts]
+        raise NotImplementedError(
+            f"Unsupported OpenQASM 3 expression node: {type(node).__name__}"
+        )
+
+    return _eval_node(tree.body)
 
 
 def parse_openqasm2_str(contents):
@@ -333,6 +574,347 @@ def parse_openqasm2_url(url, **kwargs):
     from urllib import request
 
     return parse_openqasm2_str(request.urlopen(url).read().decode(), **kwargs)
+
+
+def parse_openqasm3_str(contents):
+    """Parse the string contents of an OpenQASM 3.0 file.
+
+    This parser is dependency free and supports a practical subset of
+    OpenQASM 3 for circuit import: qubit declarations, input declarations,
+    gate applications, simple custom gates, register broadcast, and arithmetic
+    expressions. Unsupported control flow and calibration constructs raise
+    ``NotImplementedError`` explicitly.
+    """
+    rgxs = get_openqasm3_regexes()
+    sitemap = {}
+    registers = {}
+    gates = []
+    custom_gates = {}
+    env = {}
+    inputs = []
+    symbols = {}
+    expressions = {}
+    warned = {}
+
+    aliases = {
+        "u": "U3",
+        "u1": "U1",
+        "u2": "U2",
+        "u3": "U3",
+        "p": "PHASE",
+        "phase": "PHASE",
+        "id": "IDEN",
+        "i": "IDEN",
+        "cnot": "CNOT",
+        "cx": "CX",
+        "cy": "CY",
+        "cz": "CZ",
+        "h": "H",
+        "x": "X",
+        "y": "Y",
+        "z": "Z",
+        "s": "S",
+        "sdg": "SDG",
+        "t": "T",
+        "tdg": "TDG",
+        "sx": "SX",
+        "sxdg": "SXDG",
+        "swap": "SWAP",
+        "iswap": "ISWAP",
+        "rx": "RX",
+        "ry": "RY",
+        "rz": "RZ",
+        "crx": "CRX",
+        "cry": "CRY",
+        "crz": "CRZ",
+        "cu1": "CU1",
+        "cu2": "CU2",
+        "cu3": "CU3",
+        "cphase": "CPHASE",
+        "cp": "CPHASE",
+        "ccx": "CCX",
+        "ccnot": "CCX",
+        "toffoli": "CCX",
+        "cswap": "CSWAP",
+        "fredkin": "CSWAP",
+    }
+
+    def _warn_once(name, message):
+        if not warned.get(name, False):
+            warnings.warn(message, SyntaxWarning)
+            warned[name] = True
+
+    def _is_symbolic(x):
+        return not isinstance(x, numbers.Number)
+
+    def _eval_expr(expr):
+        return _openqasm_eval_expr(expr, env)
+
+    def _resolve_qubit_arg(token):
+        token = token.strip()
+        if token in env and isinstance(env[token], (tuple, list)):
+            return tuple(env[token])
+        if token in registers:
+            reg = registers[token]
+            return reg if len(reg) > 1 else reg[0]
+
+        match = re.fullmatch(r"(\w+)\[(.+)\]", token)
+        if match:
+            base, idx_expr = match.groups()
+            idx = _eval_expr(idx_expr)
+            if _is_symbolic(idx):
+                raise NotImplementedError(
+                    "Symbolic qubit indices are unsupported."
+                )
+            idx = int(idx)
+            if base in env and isinstance(env[base], (tuple, list)):
+                return env[base][idx]
+            return sitemap[f"{base}[{idx}]"]
+
+        raise NotImplementedError(f"Unknown qubit identifier: {token}")
+
+    def _broadcast_qubits(qubits):
+        sizes = {len(q) for q in qubits if isinstance(q, (tuple, list))}
+        if not sizes:
+            return [tuple(qubits)]
+        if len(sizes) != 1:
+            raise NotImplementedError(
+                "Broadcasted gate args must use registers of equal length."
+            )
+        (size,) = sizes
+        return [
+            tuple(q[i] if isinstance(q, (tuple, list)) else q for q in qubits)
+            for i in range(size)
+        ]
+
+    def _broadcast_qubit_tokens(qubits):
+        resolved = [_resolve_qubit_arg(q) for q in qubits]
+        sizes = {len(q) for q in resolved if isinstance(q, (tuple, list))}
+        if not sizes:
+            return [tuple(qubits)]
+        if len(sizes) != 1:
+            raise NotImplementedError(
+                "Broadcasted gate args must use registers of equal length."
+            )
+        (size,) = sizes
+        calls = []
+        for i in range(size):
+            call = []
+            for token, value in zip(qubits, resolved):
+                if isinstance(value, (tuple, list)):
+                    call.append(f"{token}[{i}]")
+                else:
+                    call.append(token)
+            calls.append(tuple(call))
+        return calls
+
+    def _expand_custom_gate(label, params, qubits, lines):
+        if label not in custom_gates:
+            return False
+
+        sig_params, sig_qubits, gate_body = custom_gates[label]
+        if len(sig_params) != len(params):
+            raise NotImplementedError(
+                f"Custom gate {label} expected {len(sig_params)} parameters, "
+                f"got {len(params)}"
+            )
+
+        qubit_calls = _broadcast_qubit_tokens(qubits)
+        replacer_base = dict(zip(sig_params, params))
+
+        for call_qubits in reversed(qubit_calls):
+            if len(sig_qubits) != len(call_qubits):
+                raise NotImplementedError(
+                    f"Custom gate {label} expected {len(sig_qubits)} qubits, "
+                    f"got {len(call_qubits)}"
+                )
+            replacer = {
+                **replacer_base,
+                **dict(zip(sig_qubits, map(str, call_qubits))),
+            }
+            for gl in reversed(gate_body):
+                lines.insert(0, gl.format(**replacer))
+        return True
+
+    in_comment = False
+    lines = contents.split("\n")
+    while lines:
+        line = lines.pop(0).strip()
+        if not line:
+            continue
+        if rgxs["comment"].match(line):
+            continue
+        if rgxs["comment_start"].match(line):
+            in_comment = True
+        if in_comment:
+            in_comment = not bool(rgxs["comment_end"].search(line))
+            continue
+        if rgxs["header"].match(line):
+            continue
+
+        match = rgxs["qubit"].match(line)
+        if match:
+            size_expr, name = match.groups()
+            size = 1 if size_expr is None else int(_eval_expr(size_expr))
+            registers[name] = tuple(range(len(sitemap), len(sitemap) + size))
+            for i, q in enumerate(registers[name]):
+                sitemap[f"{name}[{i}]"] = q
+            continue
+
+        match = rgxs["input"].match(line)
+        if match:
+            (name,) = match.groups()
+            inputs.append(name)
+            env[name] = name
+            symbols[name] = name
+            continue
+
+        if rgxs["output"].match(line):
+            raise NotImplementedError("Output declarations are unsupported.")
+
+        match = rgxs["const"].match(line)
+        if match:
+            name, expr = match.groups()
+            env[name] = _eval_expr(expr)
+            continue
+
+        match = rgxs["classical_decl"].match(line)
+        if match:
+            ctype, name, expr = match.groups()
+            if ctype == "bit" and expr is None:
+                continue
+            if expr is not None:
+                if expr.startswith("measure "):
+                    _warn_once(
+                        "measure",
+                        "Unsupported operation ignored: measure",
+                    )
+                    continue
+                env[name] = _eval_expr(expr)
+            continue
+
+        match = rgxs["array_decl"].match(line)
+        if match:
+            name, expr = match.groups()
+            env[name] = _eval_expr(expr.replace("{", "[").replace("}", "]"))
+            continue
+
+        match = rgxs["assign"].match(line)
+        if match:
+            name, expr = match.groups()
+            env[name] = _eval_expr(expr)
+            continue
+
+        if rgxs["ignore"].match(line):
+            op = rgxs["ignore"].match(line).group(1)
+            if op == "gphase":
+                _warn_once(
+                    "gphase",
+                    "Unsupported operation ignored: global phase",
+                )
+            else:
+                _warn_once(op, f"Unsupported operation ignored: {op}")
+            continue
+
+        if rgxs["error"].match(line):
+            raise NotImplementedError(
+                f"The following instruction is not supported: {line}"
+            )
+
+        if "@" in line:
+            raise NotImplementedError(
+                f"The following instruction is not supported: {line}"
+            )
+
+        if rgxs["gate_def"].match(line):
+            gate_lines = [line]
+            brace_count = line.count("{") - line.count("}")
+            while brace_count > 0:
+                line = lines.pop(0)
+                gate_lines.append(line)
+                brace_count += line.count("{") - line.count("}")
+
+            gate_def = " ".join(gl.strip() for gl in gate_lines)
+            gate_sig, gate_body = re.match(r"(.*)\s*{(.*)}", gate_def).groups()
+            match = rgxs["gate_sig"].match(gate_sig)
+            label = match[1]
+            sig_params = _openqasm_split_top_level(match[2])
+            sig_qubits = _openqasm_split_top_level(match[3])
+            gate_body = _openqasm_split_top_level(gate_body, ";")
+
+            for i, gate_line in enumerate(gate_body):
+                gm = rgxs["gate"].match(gate_line + ";")
+                glabel = gm[1]
+                gqubits = multi_replace(
+                    gm[3], {q: f"{{{q}}}" for q in sig_qubits}
+                )
+                if gm[2]:
+                    gparams = multi_replace(
+                        gm[2], {p: f"{{{p}}}" for p in sig_params}
+                    )
+                    gate_body[i] = f"{glabel}({gparams}) {gqubits};"
+                else:
+                    gate_body[i] = f"{glabel} {gqubits};"
+
+            custom_gates[label] = (sig_params, sig_qubits, gate_body)
+            continue
+
+        match = rgxs["gate"].match(line)
+        if match:
+            label = match[1]
+            params = _openqasm_split_top_level(match[2])
+            qubits = _openqasm_split_top_level(match[3])
+
+            if _expand_custom_gate(label, params, qubits, lines):
+                continue
+
+            label = aliases.get(label.lower(), label)
+            if label not in ALL_GATES:
+                raise NotImplementedError(f"Unknown gate: {label}")
+
+            raw_params = tuple(_eval_expr(p) for p in params)
+            qubit_calls = _broadcast_qubits(
+                [_resolve_qubit_arg(q) for q in qubits]
+            )
+            parametrize = any(_is_symbolic(p) for p in raw_params)
+            params = tuple(0.0 if _is_symbolic(p) else p for p in raw_params)
+            for call_qubits in qubit_calls:
+                if parametrize:
+                    expressions[len(gates)] = raw_params
+                gates.append(
+                    Gate(
+                        label=label,
+                        params=params,
+                        qubits=call_qubits,
+                        parametrize=parametrize,
+                    )
+                )
+            continue
+
+        raise SyntaxError(f"{line}")
+
+    return {
+        "n": len(sitemap),
+        "sitemap": sitemap,
+        "gates": gates,
+        "n_gates": len(gates),
+        "inputs": tuple(inputs),
+        "symbols": copy.copy(symbols),
+        "expressions": copy.copy(expressions),
+    }
+
+
+def parse_openqasm3_file(fname, **kwargs):
+    """Parse an OpenQASM 3.0 file."""
+    with open(fname) as f:
+        return parse_openqasm3_str(f.read(), **kwargs)
+
+
+def parse_openqasm3_url(url, **kwargs):
+    """Parse an OpenQASM 3.0 url."""
+    from urllib import request
+
+    return parse_openqasm3_str(request.urlopen(url).read().decode(), **kwargs)
 
 
 # -------------------------- core gate functions ---------------------------- #
@@ -1375,7 +1957,8 @@ class Gate:
         param_fn = PARAM_GATES[self._label]
         if self._parametrize:
             # either lazily, as tensor will be parametrized
-            return ops.PArray(param_fn, self._params)
+            shape = (2,) * (2 * len(self._qubits))
+            return ops.PArray(param_fn, self._params, shape=shape)
 
         # or cached directly into array
         try:
@@ -1892,6 +2475,39 @@ class Circuit:
         info = parse_openqasm2_url(url)
         qc = cls(info["n"], **circuit_opts)
         qc.apply_gates(info["gates"], progbar=progbar)
+        return qc
+
+    @classmethod
+    def from_openqasm3_str(cls, contents, progbar=False, **circuit_opts):
+        """Generate a ``Circuit`` instance from an OpenQASM 3.0 string."""
+        info = parse_openqasm3_str(contents)
+        qc = cls(info["n"], **circuit_opts)
+        qc.apply_gates(info["gates"], progbar=progbar)
+        qc.qasm3_inputs = info["inputs"]
+        qc.qasm3_symbols = info["symbols"]
+        qc.qasm3_expressions = info["expressions"]
+        return qc
+
+    @classmethod
+    def from_openqasm3_file(cls, fname, progbar=False, **circuit_opts):
+        """Generate a ``Circuit`` instance from an OpenQASM 3.0 file."""
+        info = parse_openqasm3_file(fname)
+        qc = cls(info["n"], **circuit_opts)
+        qc.apply_gates(info["gates"], progbar=progbar)
+        qc.qasm3_inputs = info["inputs"]
+        qc.qasm3_symbols = info["symbols"]
+        qc.qasm3_expressions = info["expressions"]
+        return qc
+
+    @classmethod
+    def from_openqasm3_url(cls, url, progbar=False, **circuit_opts):
+        """Generate a ``Circuit`` instance from an OpenQASM 3.0 url."""
+        info = parse_openqasm3_url(url)
+        qc = cls(info["n"], **circuit_opts)
+        qc.apply_gates(info["gates"], progbar=progbar)
+        qc.qasm3_inputs = info["inputs"]
+        qc.qasm3_symbols = info["symbols"]
+        qc.qasm3_expressions = info["expressions"]
         return qc
 
     @classmethod

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -2359,6 +2359,9 @@ class Circuit:
         new._sample_n_gates = self._sample_n_gates
         new._storage = self._storage.copy()
         new._sampled_conditionals = self._sampled_conditionals.copy()
+        for attr in ("qasm3_inputs", "qasm3_symbols", "qasm3_expressions"):
+            if hasattr(self, attr):
+                setattr(new, attr, copy.copy(getattr(self, attr)))
         return new
 
     def _maybe_convert(self, obj, dtype=None):
@@ -2411,13 +2414,53 @@ class Circuit:
         Parameters
         ----------
         params : dict`
-            A dictionary mapping gate numbers to the new parameters.
+            Either a dictionary mapping gate numbers to the new parameters, or
+            for QASM 3 imported circuits a dictionary mapping input names to
+            numeric values.
         """
+        if params and all(isinstance(k, str) for k in params):
+            self._set_qasm3_params(params)
+        else:
+            self._set_gate_params(params)
+
+        self.clear_storage()
+
+    def _set_gate_params(self, params):
         for i, p in params.items():
             self._psi[self.gate_tag(i)].params = p
             self._gates[i] = self._gates[i].copy_with(params=ops.asarray(p))
 
-        self.clear_storage()
+    def _set_qasm3_params(self, params):
+        if not hasattr(self, "qasm3_expressions"):
+            raise TypeError(
+                "String-keyed parameters are only supported for QASM 3 "
+                "imported circuits."
+            )
+
+        missing = set(self.qasm3_inputs) - set(params)
+        if missing:
+            raise ValueError(
+                "Missing QASM 3 input values for: "
+                + ", ".join(sorted(missing))
+            )
+
+        symbol_env = dict(self.qasm3_symbols)
+        symbol_env.update(params)
+
+        gate_params = {}
+        for i, exprs in self.qasm3_expressions.items():
+            values = tuple(_openqasm_eval_expr(expr, symbol_env) for expr in exprs)
+            if any(not isinstance(x, numbers.Number) for x in values):
+                raise ValueError(
+                    "QASM 3 input binding left unresolved symbolic values "
+                    f"for gate {i}: {values!r}"
+                )
+            gate_params[i] = values
+
+        self._set_gate_params(gate_params)
+        self.qasm3_symbols = {
+            name: symbol_env[name] for name in self.qasm3_inputs
+        }
 
     @classmethod
     def from_qsim_str(cls, contents, progbar=False, **circuit_opts):

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -154,6 +154,19 @@ def multi_replace(s, replacements):
     return s
 
 
+def _openqasm_replace_tokens(s, replacements):
+    """Replace whole identifier-like tokens in an OpenQASM fragment."""
+    if not replacements:
+        return s
+
+    pattern = "|".join(sorted(map(re.escape, replacements), key=len, reverse=True))
+    return re.sub(
+        rf"(?<!\w)({pattern})(?!\w)",
+        lambda match: replacements[match.group(1)],
+        s,
+    )
+
+
 @functools.lru_cache(None)
 def get_openqasm2_regexes():
     return {
@@ -245,6 +258,9 @@ def _openqasm_split_top_level(s, sep=","):
 
 
 def _openqasm_eval_expr(expr, env):
+    if not isinstance(expr, str):
+        return expr
+
     expr = expr.strip()
     if not expr:
         return None
@@ -396,6 +412,23 @@ def _openqasm_eval_expr(expr, env):
             return _combine_symbolic(op, lhs, rhs)
         if isinstance(node, ast.List):
             return [_eval_node(x) for x in node.elts]
+        if isinstance(node, ast.Subscript):
+            value = _eval_node(node.value)
+            index_node = node.slice
+            if hasattr(ast, "Index") and isinstance(index_node, ast.Index):
+                index_node = index_node.value
+            index = _eval_node(index_node)
+            if _is_numeric(index):
+                index = int(index)
+            else:
+                raise NotImplementedError(
+                    "Symbolic array indices are unsupported."
+                )
+            if not isinstance(value, (list, tuple)):
+                raise NotImplementedError(
+                    "Only OpenQASM 3 array-style values can be indexed."
+                )
+            return value[index]
         raise NotImplementedError(
             f"Unsupported OpenQASM 3 expression node: {type(node).__name__}"
         )
@@ -644,6 +677,9 @@ def parse_openqasm3_str(contents):
             warnings.warn(message, SyntaxWarning)
             warned[name] = True
 
+    def _warn_measure_ignored():
+        _warn_once("measure", "Unsupported operation ignored: measure")
+
     def _is_symbolic(x):
         return not isinstance(x, numbers.Number)
 
@@ -782,13 +818,11 @@ def parse_openqasm3_str(contents):
         if match:
             ctype, name, expr = match.groups()
             if ctype == "bit" and expr is None:
+                _warn_once("bit", "Unsupported operation ignored: bit")
                 continue
             if expr is not None:
-                if expr.startswith("measure "):
-                    _warn_once(
-                        "measure",
-                        "Unsupported operation ignored: measure",
-                    )
+                if expr.lstrip().startswith("measure "):
+                    _warn_measure_ignored()
                     continue
                 env[name] = _eval_expr(expr)
             continue
@@ -802,6 +836,9 @@ def parse_openqasm3_str(contents):
         match = rgxs["assign"].match(line)
         if match:
             name, expr = match.groups()
+            if expr.lstrip().startswith("measure "):
+                _warn_measure_ignored()
+                continue
             env[name] = _eval_expr(expr)
             continue
 
@@ -845,11 +882,11 @@ def parse_openqasm3_str(contents):
             for i, gate_line in enumerate(gate_body):
                 gm = rgxs["gate"].match(gate_line + ";")
                 glabel = gm[1]
-                gqubits = multi_replace(
+                gqubits = _openqasm_replace_tokens(
                     gm[3], {q: f"{{{q}}}" for q in sig_qubits}
                 )
                 if gm[2]:
-                    gparams = multi_replace(
+                    gparams = _openqasm_replace_tokens(
                         gm[2], {p: f"{{{p}}}" for p in sig_params}
                     )
                     gate_body[i] = f"{glabel}({gparams}) {gqubits};"
@@ -2413,11 +2450,25 @@ class Circuit:
 
         Parameters
         ----------
-        params : dict`
+        params : dict
             Either a dictionary mapping gate numbers to the new parameters, or
             for QASM 3 imported circuits a dictionary mapping input names to
             numeric values.
         """
+        if not params and getattr(self, "qasm3_inputs", ()):
+            self._set_qasm3_params({})
+            self.clear_storage()
+            return
+
+        if params and not (
+            all(isinstance(k, str) for k in params)
+            or all(not isinstance(k, str) for k in params)
+        ):
+            raise TypeError(
+                "Parameter keys must be all gate indices or all QASM 3 "
+                "input names."
+            )
+
         if params and all(isinstance(k, str) for k in params):
             self._set_qasm3_params(params)
         else:
@@ -2444,12 +2495,21 @@ class Circuit:
                 + ", ".join(sorted(missing))
             )
 
+        extra = set(params) - set(self.qasm3_inputs)
+        if extra:
+            raise ValueError(
+                "Unknown QASM 3 input values supplied for: "
+                + ", ".join(sorted(extra))
+            )
+
         symbol_env = dict(self.qasm3_symbols)
         symbol_env.update(params)
 
         gate_params = {}
         for i, exprs in self.qasm3_expressions.items():
-            values = tuple(_openqasm_eval_expr(expr, symbol_env) for expr in exprs)
+            values = tuple(
+                _openqasm_eval_expr(expr, symbol_env) for expr in exprs
+            )
             if any(not isinstance(x, numbers.Number) for x in values):
                 raise ValueError(
                     "QASM 3 input binding left unresolved symbolic values "

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -304,22 +304,18 @@ def _openqasm_eval_expr(expr, env):
         "pow": pow,
     }
 
-    def _to_expr_str(x):
-        if isinstance(x, str):
-            return x
-        return repr(x)
-
     def _combine_symbolic(op, *xs):
+        fmt = lambda x: x if isinstance(x, str) else repr(x)
         if len(xs) == 1:
             (x,) = xs
             if op == "+":
-                return f"(+{_to_expr_str(x)})"
+                return f"(+{fmt(x)})"
             if op == "-":
-                return f"(-{_to_expr_str(x)})"
+                return f"(-{fmt(x)})"
             if op == "~":
-                return f"(~{_to_expr_str(x)})"
+                return f"(~{fmt(x)})"
             if op == "!":
-                return f"(!{_to_expr_str(x)})"
+                return f"(!{fmt(x)})"
         if op in {
             "sin",
             "cos",
@@ -333,11 +329,8 @@ def _openqasm_eval_expr(expr, env):
             "sqrt",
             "abs",
         }:
-            return f"{op}({', '.join(map(_to_expr_str, xs))})"
-        return f"({_to_expr_str(xs[0])} {op} {_to_expr_str(xs[1])})"
-
-    def _is_numeric(x):
-        return isinstance(x, numbers.Number)
+            return f"{op}({', '.join(map(fmt, xs))})"
+        return f"({fmt(xs[0])} {op} {fmt(xs[1])})"
 
     allowed_compare_ops = {
         ast.Eq: ("==", operator.eq),
@@ -368,7 +361,9 @@ def _openqasm_eval_expr(expr, env):
                     f"Unsupported OpenQASM 3 operator: {optype.__name__}"
                 )
             op, fn = allowed_binary_ops[optype]
-            if _is_numeric(lhs) and _is_numeric(rhs):
+            if isinstance(lhs, numbers.Number) and isinstance(
+                rhs, numbers.Number
+            ):
                 return fn(lhs, rhs)
             return _combine_symbolic(op, lhs, rhs)
         if isinstance(node, ast.UnaryOp):
@@ -379,7 +374,7 @@ def _openqasm_eval_expr(expr, env):
                     f"Unsupported OpenQASM 3 unary op: {optype.__name__}"
                 )
             op, fn = allowed_unary_ops[optype]
-            if _is_numeric(x):
+            if isinstance(x, numbers.Number):
                 return fn(x)
             return _combine_symbolic(op, x)
         if isinstance(node, ast.Call):
@@ -393,7 +388,7 @@ def _openqasm_eval_expr(expr, env):
                     f"Unsupported OpenQASM 3 function: {name}"
                 )
             args = [_eval_node(a) for a in node.args]
-            if all(_is_numeric(a) for a in args):
+            if all(isinstance(a, numbers.Number) for a in args):
                 return allowed_fns[name](*args)
             return _combine_symbolic(name, *args)
         if isinstance(node, ast.Compare):
@@ -409,7 +404,9 @@ def _openqasm_eval_expr(expr, env):
                     f"Unsupported OpenQASM 3 compare op: {optype.__name__}"
                 )
             op, fn = allowed_compare_ops[optype]
-            if _is_numeric(lhs) and _is_numeric(rhs):
+            if isinstance(lhs, numbers.Number) and isinstance(
+                rhs, numbers.Number
+            ):
                 return fn(lhs, rhs)
             return _combine_symbolic(op, lhs, rhs)
         if isinstance(node, ast.List):
@@ -420,7 +417,7 @@ def _openqasm_eval_expr(expr, env):
             if hasattr(ast, "Index") and isinstance(index_node, ast.Index):
                 index_node = index_node.value
             index = _eval_node(index_node)
-            if _is_numeric(index):
+            if isinstance(index, numbers.Number):
                 index = int(index)
             else:
                 raise NotImplementedError(
@@ -704,20 +701,6 @@ def parse_openqasm3_str(contents):
         "fredkin": "CSWAP",
     }
 
-    def _warn_once(name, message):
-        if not warned.get(name, False):
-            warnings.warn(message, SyntaxWarning)
-            warned[name] = True
-
-    def _warn_measure_ignored():
-        _warn_once("measure", "Unsupported operation ignored: measure")
-
-    def _is_symbolic(x):
-        return not isinstance(x, numbers.Number)
-
-    def _eval_expr(expr):
-        return _openqasm_eval_expr(expr, env)
-
     def _resolve_qubit_arg(token):
         token = token.strip()
         if token in env and isinstance(env[token], (tuple, list)):
@@ -729,8 +712,8 @@ def parse_openqasm3_str(contents):
         match = re.fullmatch(r"(\w+)\[(.+)\]", token)
         if match:
             base, idx_expr = match.groups()
-            idx = _eval_expr(idx_expr)
-            if _is_symbolic(idx):
+            idx = _openqasm_eval_expr(idx_expr, env)
+            if not isinstance(idx, numbers.Number):
                 raise NotImplementedError(
                     "Symbolic qubit indices are unsupported."
                 )
@@ -740,69 +723,6 @@ def parse_openqasm3_str(contents):
             return sitemap[f"{base}[{idx}]"]
 
         raise NotImplementedError(f"Unknown qubit identifier: {token}")
-
-    def _broadcast_qubits(qubits):
-        sizes = {len(q) for q in qubits if isinstance(q, (tuple, list))}
-        if not sizes:
-            return [tuple(qubits)]
-        if len(sizes) != 1:
-            raise NotImplementedError(
-                "Broadcasted gate args must use registers of equal length."
-            )
-        (size,) = sizes
-        return [
-            tuple(q[i] if isinstance(q, (tuple, list)) else q for q in qubits)
-            for i in range(size)
-        ]
-
-    def _broadcast_qubit_tokens(qubits):
-        resolved = [_resolve_qubit_arg(q) for q in qubits]
-        sizes = {len(q) for q in resolved if isinstance(q, (tuple, list))}
-        if not sizes:
-            return [tuple(qubits)]
-        if len(sizes) != 1:
-            raise NotImplementedError(
-                "Broadcasted gate args must use registers of equal length."
-            )
-        (size,) = sizes
-        calls = []
-        for i in range(size):
-            call = []
-            for token, value in zip(qubits, resolved):
-                if isinstance(value, (tuple, list)):
-                    call.append(f"{token}[{i}]")
-                else:
-                    call.append(token)
-            calls.append(tuple(call))
-        return calls
-
-    def _expand_custom_gate(label, params, qubits, lines):
-        if label not in custom_gates:
-            return False
-
-        sig_params, sig_qubits, gate_body = custom_gates[label]
-        if len(sig_params) != len(params):
-            raise NotImplementedError(
-                f"Custom gate {label} expected {len(sig_params)} parameters, "
-                f"got {len(params)}"
-            )
-
-        qubit_calls = _broadcast_qubit_tokens(qubits)
-        replacer_base = dict(zip(sig_params, params))
-
-        for call_qubits in reversed(qubit_calls):
-            if len(sig_qubits) != len(call_qubits):
-                raise NotImplementedError(
-                    f"Custom gate {label} expected {len(sig_qubits)} qubits, "
-                    f"got {len(call_qubits)}"
-                )
-            replacer = {
-                **replacer_base,
-                **dict(zip(sig_qubits, map(str, call_qubits))),
-            }
-            for gl in reversed(gate_body):
-                lines.insert(0, gl.format(**replacer))
-        return True
 
     in_comment = False
     lines = contents.split("\n")
@@ -823,7 +743,11 @@ def parse_openqasm3_str(contents):
         match = rgxs["qubit"].match(line)
         if match:
             size_expr, name = match.groups()
-            size = 1 if size_expr is None else int(_eval_expr(size_expr))
+            size = (
+                1
+                if size_expr is None
+                else int(_openqasm_eval_expr(size_expr, env))
+            )
             registers[name] = tuple(range(len(sitemap), len(sitemap) + size))
             for i, q in enumerate(registers[name]):
                 sitemap[f"{name}[{i}]"] = q
@@ -843,46 +767,64 @@ def parse_openqasm3_str(contents):
         match = rgxs["const"].match(line)
         if match:
             name, expr = match.groups()
-            env[name] = _eval_expr(expr)
+            env[name] = _openqasm_eval_expr(expr, env)
             continue
 
         match = rgxs["classical_decl"].match(line)
         if match:
             ctype, name, expr = match.groups()
             if ctype == "bit" and expr is None:
-                _warn_once("bit", "Unsupported operation ignored: bit")
+                if not warned.get("bit", False):
+                    warnings.warn(
+                        "Unsupported operation ignored: bit",
+                        SyntaxWarning,
+                    )
+                    warned["bit"] = True
                 continue
             if expr is not None:
                 if expr.lstrip().startswith("measure "):
-                    _warn_measure_ignored()
+                    if not warned.get("measure", False):
+                        warnings.warn(
+                            "Unsupported operation ignored: measure",
+                            SyntaxWarning,
+                        )
+                        warned["measure"] = True
                     continue
-                env[name] = _eval_expr(expr)
+                env[name] = _openqasm_eval_expr(expr, env)
             continue
 
         match = rgxs["array_decl"].match(line)
         if match:
             name, expr = match.groups()
-            env[name] = _eval_expr(expr.replace("{", "[").replace("}", "]"))
+            env[name] = _openqasm_eval_expr(
+                expr.replace("{", "[").replace("}", "]"), env
+            )
             continue
 
         match = rgxs["assign"].match(line)
         if match:
             name, expr = match.groups()
             if expr.lstrip().startswith("measure "):
-                _warn_measure_ignored()
+                if not warned.get("measure", False):
+                    warnings.warn(
+                        "Unsupported operation ignored: measure",
+                        SyntaxWarning,
+                    )
+                    warned["measure"] = True
                 continue
-            env[name] = _eval_expr(expr)
+            env[name] = _openqasm_eval_expr(expr, env)
             continue
 
         if rgxs["ignore"].match(line):
             op = rgxs["ignore"].match(line).group(1)
-            if op == "gphase":
-                _warn_once(
-                    "gphase",
-                    "Unsupported operation ignored: global phase",
+            if not warned.get(op, False):
+                warnings.warn(
+                    "Unsupported operation ignored: global phase"
+                    if op == "gphase"
+                    else f"Unsupported operation ignored: {op}",
+                    SyntaxWarning,
                 )
-            else:
-                _warn_once(op, f"Unsupported operation ignored: {op}")
+                warned[op] = True
             continue
 
         if rgxs["error"].match(line):
@@ -934,19 +876,83 @@ def parse_openqasm3_str(contents):
             params = _openqasm_split_top_level(match[2])
             qubits = _openqasm_split_top_level(match[3])
 
-            if _expand_custom_gate(label, params, qubits, lines):
+            if label in custom_gates:
+                sig_params, sig_qubits, gate_body = custom_gates[label]
+                if len(sig_params) != len(params):
+                    raise NotImplementedError(
+                        f"Custom gate {label} expected "
+                        f"{len(sig_params)} parameters, got {len(params)}"
+                    )
+
+                replacer_base = dict(zip(sig_params, params))
+                resolved = [_resolve_qubit_arg(q) for q in qubits]
+                sizes = {
+                    len(q) for q in resolved if isinstance(q, (tuple, list))
+                }
+                if not sizes:
+                    qubit_calls = [tuple(qubits)]
+                else:
+                    if len(sizes) != 1:
+                        raise NotImplementedError(
+                            "Broadcasted gate args must use registers of "
+                            "equal length."
+                        )
+                    (size,) = sizes
+                    qubit_calls = [
+                        tuple(
+                            f"{token}[{i}]"
+                            if isinstance(value, (tuple, list))
+                            else token
+                            for token, value in zip(qubits, resolved)
+                        )
+                        for i in range(size)
+                    ]
+
+                for call_qubits in reversed(qubit_calls):
+                    if len(sig_qubits) != len(call_qubits):
+                        raise NotImplementedError(
+                            f"Custom gate {label} expected "
+                            f"{len(sig_qubits)} qubits, "
+                            f"got {len(call_qubits)}"
+                        )
+                    replacer = {
+                        **replacer_base,
+                        **dict(zip(sig_qubits, map(str, call_qubits))),
+                    }
+                    for gl in reversed(gate_body):
+                        lines.insert(0, gl.format(**replacer))
                 continue
 
             label = aliases.get(label.lower(), label)
             if label not in ALL_GATES:
                 raise NotImplementedError(f"Unknown gate: {label}")
 
-            raw_params = tuple(_eval_expr(p) for p in params)
-            qubit_calls = _broadcast_qubits(
-                [_resolve_qubit_arg(q) for q in qubits]
+            raw_params = tuple(_openqasm_eval_expr(p, env) for p in params)
+            resolved = [_resolve_qubit_arg(q) for q in qubits]
+            sizes = {len(q) for q in resolved if isinstance(q, (tuple, list))}
+            if not sizes:
+                qubit_calls = [tuple(resolved)]
+            else:
+                if len(sizes) != 1:
+                    raise NotImplementedError(
+                        "Broadcasted gate args must use registers of equal "
+                        "length."
+                    )
+                (size,) = sizes
+                qubit_calls = [
+                    tuple(
+                        value[i] if isinstance(value, (tuple, list)) else value
+                        for value in resolved
+                    )
+                    for i in range(size)
+                ]
+            parametrize = any(
+                not isinstance(p, numbers.Number) for p in raw_params
             )
-            parametrize = any(_is_symbolic(p) for p in raw_params)
-            params = tuple(0.0 if _is_symbolic(p) else p for p in raw_params)
+            params = tuple(
+                0.0 if not isinstance(p, numbers.Number) else p
+                for p in raw_params
+            )
             for call_qubits in qubit_calls:
                 if parametrize:
                     expressions[len(gates)] = raw_params
@@ -2515,11 +2521,6 @@ class Circuit:
             for QASM 3 imported circuits a dictionary mapping input names to
             numeric values.
         """
-        if not params and getattr(self, "qasm3_inputs", ()):
-            self._set_qasm3_params({})
-            self.clear_storage()
-            return
-
         if params and not (
             all(isinstance(k, str) for k in params)
             or all(not isinstance(k, str) for k in params)
@@ -2529,58 +2530,51 @@ class Circuit:
                 "input names."
             )
 
-        if params and all(isinstance(k, str) for k in params):
-            self._set_qasm3_params(params)
-        else:
-            self._set_gate_params(params)
+        if hasattr(self, "qasm3_inputs") and (
+            not params or all(isinstance(k, str) for k in params)
+        ):
+            missing = set(self.qasm3_inputs) - set(params)
+            if missing:
+                raise ValueError(
+                    "Missing QASM 3 input values for: "
+                    + ", ".join(sorted(missing))
+                )
 
-        self.clear_storage()
+            extra = set(params) - set(self.qasm3_inputs)
+            if extra:
+                raise ValueError(
+                    "Unknown QASM 3 input values supplied for: "
+                    + ", ".join(sorted(extra))
+                )
 
-    def _set_gate_params(self, params):
-        for i, p in params.items():
-            self._psi[self.gate_tag(i)].params = p
-            self._gates[i] = self._gates[i].copy_with(params=ops.asarray(p))
+            symbol_env = dict(self.qasm3_symbols)
+            symbol_env.update(params)
 
-    def _set_qasm3_params(self, params):
-        if not hasattr(self, "qasm3_expressions"):
+            params = {}
+            for i, exprs in self.qasm3_expressions.items():
+                values = tuple(
+                    _openqasm_eval_expr(expr, symbol_env) for expr in exprs
+                )
+                if any(not isinstance(x, numbers.Number) for x in values):
+                    raise ValueError(
+                        "QASM 3 input binding left unresolved symbolic values "
+                        f"for gate {i}: {values!r}"
+                    )
+                params[i] = values
+
+            self.qasm3_symbols = {
+                name: symbol_env[name] for name in self.qasm3_inputs
+            }
+        elif params and all(isinstance(k, str) for k in params):
             raise TypeError(
                 "String-keyed parameters are only supported for QASM 3 "
                 "imported circuits."
             )
 
-        missing = set(self.qasm3_inputs) - set(params)
-        if missing:
-            raise ValueError(
-                "Missing QASM 3 input values for: "
-                + ", ".join(sorted(missing))
-            )
-
-        extra = set(params) - set(self.qasm3_inputs)
-        if extra:
-            raise ValueError(
-                "Unknown QASM 3 input values supplied for: "
-                + ", ".join(sorted(extra))
-            )
-
-        symbol_env = dict(self.qasm3_symbols)
-        symbol_env.update(params)
-
-        gate_params = {}
-        for i, exprs in self.qasm3_expressions.items():
-            values = tuple(
-                _openqasm_eval_expr(expr, symbol_env) for expr in exprs
-            )
-            if any(not isinstance(x, numbers.Number) for x in values):
-                raise ValueError(
-                    "QASM 3 input binding left unresolved symbolic values "
-                    f"for gate {i}: {values!r}"
-                )
-            gate_params[i] = values
-
-        self._set_gate_params(gate_params)
-        self.qasm3_symbols = {
-            name: symbol_env[name] for name in self.qasm3_inputs
-        }
+        for i, p in params.items():
+            self._psi[self.gate_tag(i)].params = p
+            self._gates[i] = self._gates[i].copy_with(params=ops.asarray(p))
+        self.clear_storage()
 
     @classmethod
     def from_qsim_str(cls, contents, progbar=False, **circuit_opts):
@@ -2687,13 +2681,10 @@ class Circuit:
         Circuit
             The parsed circuit instance.
         """
-        info = parse_openqasm3_file(fname)
-        qc = cls(info["n"], **circuit_opts)
-        qc.apply_gates(info["gates"], progbar=progbar)
-        qc.qasm3_inputs = info["inputs"]
-        qc.qasm3_symbols = info["symbols"]
-        qc.qasm3_expressions = info["expressions"]
-        return qc
+        with open(fname) as f:
+            return cls.from_openqasm3_str(
+                f.read(), progbar=progbar, **circuit_opts
+            )
 
     @classmethod
     def from_openqasm3_url(cls, url, progbar=False, **circuit_opts):
@@ -2713,13 +2704,13 @@ class Circuit:
         Circuit
             The parsed circuit instance.
         """
-        info = parse_openqasm3_url(url)
-        qc = cls(info["n"], **circuit_opts)
-        qc.apply_gates(info["gates"], progbar=progbar)
-        qc.qasm3_inputs = info["inputs"]
-        qc.qasm3_symbols = info["symbols"]
-        qc.qasm3_expressions = info["expressions"]
-        return qc
+        from urllib import request
+
+        return cls.from_openqasm3_str(
+            request.urlopen(url).read().decode(),
+            progbar=progbar,
+            **circuit_opts,
+        )
 
     @classmethod
     def from_gates(cls, gates, N=None, progbar=False, **kwargs):

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -2,8 +2,8 @@
 
 import ast
 import cmath
-import copy
 import collections.abc
+import copy
 import functools
 import itertools
 import math

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -2542,6 +2542,7 @@ class Circuit:
     def apply_to_arrays(self, fn):
         """Apply a function to all the arrays in the circuit."""
         self._psi.apply_to_arrays(fn)
+        self._named_params = tree_map(fn, self._named_params)
 
     @staticmethod
     def _normalize_named_param_value(value):
@@ -2593,9 +2594,34 @@ class Circuit:
 
         if gate_expressions is None:
             gate_expressions = {}
-        self._named_param_exprs = {
-            int(i): tuple(exprs) for i, exprs in gate_expressions.items()
-        }
+
+        normalized_gate_expressions = {}
+        for i, exprs in gate_expressions.items():
+            i = int(i)
+            exprs = tuple(exprs)
+
+            if not (0 <= int(i) < len(self._gates)):
+                raise ValueError(
+                    "Named parameter expressions reference unknown gate "
+                    f"index: {i}"
+                )
+
+            gate = self._gates[i]
+            if not gate.parametrize:
+                raise ValueError(
+                    "Named parameter expressions require parametrized gate "
+                    f"indices, got non-parametrized gate: {i}"
+                )
+
+            if len(exprs) != len(gate.params):
+                raise ValueError(
+                    "Named parameter expression arity does not match gate "
+                    f"{i}: expected {len(gate.params)}, got {len(exprs)}"
+                )
+
+            normalized_gate_expressions[i] = exprs
+
+        self._named_param_exprs = normalized_gate_expressions
         self._apply_named_param_updates()
         self.clear_storage()
 

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -3,6 +3,7 @@
 import ast
 import cmath
 import copy
+import collections.abc
 import functools
 import itertools
 import math
@@ -260,6 +261,9 @@ def _openqasm_split_top_level(s, sep=","):
 
 
 def _openqasm_eval_expr(expr, env):
+    if callable(expr):
+        return expr(env)
+
     if not isinstance(expr, str):
         return expr
 
@@ -290,19 +294,32 @@ def _openqasm_eval_expr(expr, env):
         ast.Not: ("!", operator.not_),
     }
     allowed_fns = {
-        "sin": math.sin,
-        "cos": math.cos,
-        "tan": math.tan,
-        "asin": math.asin,
-        "acos": math.acos,
-        "atan": math.atan,
-        "exp": math.exp,
-        "ln": math.log,
-        "log": math.log,
-        "sqrt": math.sqrt,
-        "abs": abs,
+        "sin": lambda x: do("sin", x),
+        "cos": lambda x: do("cos", x),
+        "tan": lambda x: do("tan", x),
+        "asin": lambda x: do("arcsin", x),
+        "acos": lambda x: do("arccos", x),
+        "atan": lambda x: do("arctan", x),
+        "exp": lambda x: do("exp", x),
+        "ln": lambda x: do("log", x),
+        "log": lambda x: do("log", x),
+        "sqrt": lambda x: do("sqrt", x),
+        "abs": lambda x: do("abs", x),
         "pow": pow,
     }
+
+    def _placeholder_passthrough(*xs):
+        for x in xs:
+            if _is_interface_placeholder(x):
+                return x
+        raise TypeError("No placeholder value supplied.")
+
+    def _is_symbolic(x):
+        if isinstance(x, str):
+            return True
+        if isinstance(x, (list, tuple)):
+            return any(_is_symbolic(xi) for xi in x)
+        return False
 
     def _combine_symbolic(op, *xs):
         fmt = lambda x: x if isinstance(x, str) else repr(x)
@@ -361,11 +378,13 @@ def _openqasm_eval_expr(expr, env):
                     f"Unsupported OpenQASM 3 operator: {optype.__name__}"
                 )
             op, fn = allowed_binary_ops[optype]
-            if isinstance(lhs, numbers.Number) and isinstance(
-                rhs, numbers.Number
+            if _is_symbolic(lhs) or _is_symbolic(rhs):
+                return _combine_symbolic(op, lhs, rhs)
+            if _is_interface_placeholder(lhs) or _is_interface_placeholder(
+                rhs
             ):
-                return fn(lhs, rhs)
-            return _combine_symbolic(op, lhs, rhs)
+                return _placeholder_passthrough(lhs, rhs)
+            return fn(lhs, rhs)
         if isinstance(node, ast.UnaryOp):
             x = _eval_node(node.operand)
             optype = type(node.op)
@@ -374,9 +393,11 @@ def _openqasm_eval_expr(expr, env):
                     f"Unsupported OpenQASM 3 unary op: {optype.__name__}"
                 )
             op, fn = allowed_unary_ops[optype]
-            if isinstance(x, numbers.Number):
-                return fn(x)
-            return _combine_symbolic(op, x)
+            if _is_symbolic(x):
+                return _combine_symbolic(op, x)
+            if _is_interface_placeholder(x):
+                return x
+            return fn(x)
         if isinstance(node, ast.Call):
             if not isinstance(node.func, ast.Name):
                 raise NotImplementedError(
@@ -388,9 +409,11 @@ def _openqasm_eval_expr(expr, env):
                     f"Unsupported OpenQASM 3 function: {name}"
                 )
             args = [_eval_node(a) for a in node.args]
-            if all(isinstance(a, numbers.Number) for a in args):
-                return allowed_fns[name](*args)
-            return _combine_symbolic(name, *args)
+            if any(_is_symbolic(a) for a in args):
+                return _combine_symbolic(name, *args)
+            if any(_is_interface_placeholder(a) for a in args):
+                return _placeholder_passthrough(*args)
+            return allowed_fns[name](*args)
         if isinstance(node, ast.Compare):
             if len(node.ops) != 1 or len(node.comparators) != 1:
                 raise NotImplementedError(
@@ -404,11 +427,13 @@ def _openqasm_eval_expr(expr, env):
                     f"Unsupported OpenQASM 3 compare op: {optype.__name__}"
                 )
             op, fn = allowed_compare_ops[optype]
-            if isinstance(lhs, numbers.Number) and isinstance(
-                rhs, numbers.Number
+            if _is_symbolic(lhs) or _is_symbolic(rhs):
+                return _combine_symbolic(op, lhs, rhs)
+            if _is_interface_placeholder(lhs) or _is_interface_placeholder(
+                rhs
             ):
-                return fn(lhs, rhs)
-            return _combine_symbolic(op, lhs, rhs)
+                return _placeholder_passthrough(lhs, rhs)
+            return fn(lhs, rhs)
         if isinstance(node, ast.List):
             return [_eval_node(x) for x in node.elts]
         if isinstance(node, ast.Subscript):
@@ -433,6 +458,27 @@ def _openqasm_eval_expr(expr, env):
         )
 
     return _eval_node(tree.body)
+
+
+def _is_interface_placeholder(x):
+    try:
+        from .interface import Placeholder
+    except ImportError:
+        return False
+    return isinstance(x, Placeholder)
+
+
+def _placeholder_param_vector(values):
+    from .interface import Placeholder
+
+    for value in values:
+        if _is_interface_placeholder(value):
+            dtype = getattr(value, "dtype", "float64")
+            if dtype in (None, "unknown"):
+                dtype = "float64"
+            return Placeholder(np.empty((len(values),), dtype=dtype))
+
+    raise TypeError("No placeholder values supplied.")
 
 
 def parse_openqasm2_str(contents):
@@ -950,7 +996,7 @@ def parse_openqasm3_str(contents):
                 not isinstance(p, numbers.Number) for p in raw_params
             )
             params = tuple(
-                0.0 if not isinstance(p, numbers.Number) else p
+                float("nan") if not isinstance(p, numbers.Number) else p
                 for p in raw_params
             )
             for call_qubits in qubit_calls:
@@ -2440,6 +2486,8 @@ class Circuit:
         self._sample_n_gates = -1
         self._storage = dict()
         self._sampled_conditionals = dict()
+        self._named_params = {}
+        self._named_param_exprs = {}
 
     def copy(self):
         """Copy the circuit and its state."""
@@ -2462,9 +2510,8 @@ class Circuit:
         new._sample_n_gates = self._sample_n_gates
         new._storage = self._storage.copy()
         new._sampled_conditionals = self._sampled_conditionals.copy()
-        for attr in ("qasm3_inputs", "qasm3_symbols", "qasm3_expressions"):
-            if hasattr(self, attr):
-                setattr(new, attr, copy.copy(getattr(self, attr)))
+        new._named_params = copy.copy(self._named_params)
+        new._named_param_exprs = copy.copy(self._named_param_exprs)
         return new
 
     def _maybe_convert(self, obj, dtype=None):
@@ -2496,20 +2543,102 @@ class Circuit:
         """Apply a function to all the arrays in the circuit."""
         self._psi.apply_to_arrays(fn)
 
+    @staticmethod
+    def _normalize_named_param_value(value):
+        if _is_interface_placeholder(value):
+            return value
+        if isinstance(value, numbers.Number):
+            return ops.asarray(value)
+        return value
+
+    @property
+    def named_params(self):
+        """Named circuit parameters and their current values."""
+        return copy.copy(self._named_params)
+
+    @property
+    def named_param_names(self):
+        """Names of registered circuit parameters."""
+        return tuple(self._named_params)
+
+    @property
+    def param_expressions(self):
+        """Gate parameter expressions keyed by gate index."""
+        return copy.copy(self._named_param_exprs)
+
+    def register_named_params(self, named_params, gate_expressions=None):
+        """Register named circuit parameters and gate dependencies.
+
+        Parameters
+        ----------
+        named_params : sequence[str] or mapping[str, scalar]
+            Either names to register, which default to ``nan`` until bound,
+            or a mapping supplying initial values.
+        gate_expressions : mapping[int, tuple], optional
+            Mapping from gate index to the expressions used to generate that
+            gate's parameters. Each expression can be a constant, a string
+            expression referencing the named parameters, or a callable taking
+            the current named parameter mapping.
+        """
+        if isinstance(named_params, collections.abc.Mapping):
+            self._named_params = {
+                name: self._normalize_named_param_value(value)
+                for name, value in named_params.items()
+            }
+        else:
+            self._named_params = {
+                name: self._normalize_named_param_value(float("nan"))
+                for name in tuple(named_params)
+            }
+
+        if gate_expressions is None:
+            gate_expressions = {}
+        self._named_param_exprs = {
+            int(i): tuple(exprs) for i, exprs in gate_expressions.items()
+        }
+        self._apply_named_param_updates()
+        self.clear_storage()
+
+    def _set_gate_params(self, i, params):
+        self._psi[self.gate_tag(i)].params = params
+        self._gates[i] = self._gates[i].copy_with(params=ops.asarray(params))
+
+    def _apply_named_param_updates(self):
+        if not self._named_param_exprs:
+            return
+
+        env = dict(self._named_params)
+        for i, exprs in self._named_param_exprs.items():
+            values = tuple(_openqasm_eval_expr(expr, env) for expr in exprs)
+            if any(isinstance(x, str) for x in values):
+                raise ValueError(
+                    "Named parameter binding left unresolved symbolic values "
+                    f"for gate {i}: {values!r}"
+                )
+            if any(_is_interface_placeholder(x) for x in values):
+                values = _placeholder_param_vector(values)
+            self._set_gate_params(i, values)
+
     def get_params(self):
         """Get a pytree - in this case a dict - of all the parameters in the
         circuit.
 
         Returns
         -------
-        dict[int, tuple]
-            A dictionary mapping gate numbers to their parameters.
+        dict
+            Dictionary containing any named parameters plus any directly
+            parametrized gates not driven by named parameter expressions.
         """
-        return {
-            i: self._psi[self.gate_tag(i)].params
-            for i, gate in enumerate(self._gates)
-            if gate.parametrize
-        }
+        params = dict(self._named_params)
+        managed_gates = set(self._named_param_exprs)
+        params.update(
+            {
+                i: self._psi[self.gate_tag(i)].params
+                for i, gate in enumerate(self._gates)
+                if gate.parametrize and i not in managed_gates
+            }
+        )
+        return params
 
     def set_params(self, params):
         """Set the parameters of the circuit.
@@ -2517,63 +2646,49 @@ class Circuit:
         Parameters
         ----------
         params : dict
-            Either a dictionary mapping gate numbers to the new parameters, or
-            for QASM 3 imported circuits a dictionary mapping input names to
-            numeric values.
+            Dictionary mapping gate numbers and/or registered named parameter
+            names to new values.
         """
-        if params and not (
-            all(isinstance(k, str) for k in params)
-            or all(not isinstance(k, str) for k in params)
-        ):
-            raise TypeError(
-                "Parameter keys must be all gate indices or all QASM 3 "
-                "input names."
-            )
-
-        if hasattr(self, "qasm3_inputs") and (
-            not params or all(isinstance(k, str) for k in params)
-        ):
-            missing = set(self.qasm3_inputs) - set(params)
-            if missing:
-                raise ValueError(
-                    "Missing QASM 3 input values for: "
-                    + ", ".join(sorted(missing))
-                )
-
-            extra = set(params) - set(self.qasm3_inputs)
-            if extra:
-                raise ValueError(
-                    "Unknown QASM 3 input values supplied for: "
-                    + ", ".join(sorted(extra))
-                )
-
-            symbol_env = dict(self.qasm3_symbols)
-            symbol_env.update(params)
-
+        if params is None:
             params = {}
-            for i, exprs in self.qasm3_expressions.items():
-                values = tuple(
-                    _openqasm_eval_expr(expr, symbol_env) for expr in exprs
-                )
-                if any(not isinstance(x, numbers.Number) for x in values):
-                    raise ValueError(
-                        "QASM 3 input binding left unresolved symbolic values "
-                        f"for gate {i}: {values!r}"
-                    )
-                params[i] = values
 
-            self.qasm3_symbols = {
-                name: symbol_env[name] for name in self.qasm3_inputs
-            }
-        elif params and all(isinstance(k, str) for k in params):
+        named_updates = {k: v for k, v in params.items() if isinstance(k, str)}
+        gate_updates = {
+            k: v for k, v in params.items() if not isinstance(k, str)
+        }
+
+        if named_updates and not self._named_params:
             raise TypeError(
-                "String-keyed parameters are only supported for QASM 3 "
-                "imported circuits."
+                "String-keyed parameters require registered named "
+                "parameters."
             )
 
-        for i, p in params.items():
-            self._psi[self.gate_tag(i)].params = p
-            self._gates[i] = self._gates[i].copy_with(params=ops.asarray(p))
+        extra = set(named_updates) - set(self._named_params)
+        if extra:
+            raise ValueError(
+                "Unknown named parameter values supplied for: "
+                + ", ".join(sorted(extra))
+            )
+
+        overlap = set(gate_updates) & set(self._named_param_exprs)
+        if overlap:
+            raise ValueError(
+                "Cannot directly set gate parameters managed by named "
+                "parameter expressions: "
+                + ", ".join(map(str, sorted(overlap)))
+            )
+
+        if named_updates:
+            self._named_params.update(
+                {
+                    name: self._normalize_named_param_value(value)
+                    for name, value in named_updates.items()
+                }
+            )
+            self._apply_named_param_updates()
+
+        for i, p in gate_updates.items():
+            self._set_gate_params(i, p)
         self.clear_storage()
 
     @classmethod
@@ -2651,16 +2766,21 @@ class Circuit:
         -------
         Circuit
             A circuit populated with the parsed gates. If symbolic ``input``
-            declarations are present, the returned circuit tracks them via
-            ``qasm3_inputs``, ``qasm3_symbols``, and ``qasm3_expressions`` so
-            that :meth:`set_params` can bind named values later.
+            declarations are present, they are registered as generic named
+            circuit parameters so that :meth:`set_params` can bind them later.
         """
         info = parse_openqasm3_str(contents)
         qc = cls(info["n"], **circuit_opts)
         qc.apply_gates(info["gates"], progbar=progbar)
-        qc.qasm3_inputs = info["inputs"]
-        qc.qasm3_symbols = info["symbols"]
-        qc.qasm3_expressions = info["expressions"]
+        qc.register_named_params(
+            {
+                name: (
+                    value if not isinstance(value, str) else float("nan")
+                )
+                for name, value in info["symbols"].items()
+            },
+            info["expressions"],
+        )
         return qc
 
     @classmethod

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -512,6 +512,24 @@ class TestCircuit:
         assert tuple(circ2.gates[0].params) == pytest.approx((0.2,))
         assert tuple(circ2.gates[1].params) == pytest.approx((0.4, 0.5, 0.6))
 
+    def test_get_params_excludes_named_expression_managed_gate_indices(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            input float theta;
+            qubit[2] q;
+            rx(theta) q[0];
+            """
+        )
+        circ.u3(0.1, 0.2, 0.3, 1, parametrize=True)
+
+        params = circ.get_params()
+        assert set(params) == {"theta", 1}
+        assert 0 not in params
+        assert np.isnan(params["theta"])
+        assert tuple(params[1]) == pytest.approx((0.1, 0.2, 0.3))
+
     def test_openqasm3_named_params_pack_unpack_roundtrip(self):
         circ = qtn.Circuit.from_openqasm3_str(
             """
@@ -564,6 +582,30 @@ class TestCircuit:
         assert tuple(circ.gates[1].params) == pytest.approx(
             (math.cos(0.3),)
         )
+
+    def test_circuit_register_named_params_sequence_and_callable(self):
+        circ = qtn.Circuit(1)
+        circ.rx(np.nan, 0, parametrize=True)
+        circ.register_named_params(
+            ["theta"],
+            {0: (lambda env: env["theta"] / 2,)},
+        )
+
+        assert circ.named_param_names == ("theta",)
+        assert np.isnan(circ.named_params["theta"])
+        assert math.isnan(circ.gates[0].params[0])
+
+        circ.set_params({"theta": np.array(0.6)})
+        assert tuple(circ.gates[0].params) == pytest.approx((0.3,))
+
+    def test_circuit_set_params_string_keys_require_registration(self):
+        circ = qtn.Circuit(1)
+        circ.rx(0.1, 0, parametrize=True)
+
+        with pytest.raises(
+            TypeError, match="require registered named parameters"
+        ):
+            circ.set_params({"theta": 0.2})
 
     def test_openqasm3_output_decl_unsupported(self):
         with pytest.raises(NotImplementedError, match="Output declarations"):

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -226,7 +226,8 @@ class TestCircuit:
         assert circ.gates[0].label == "RX"
         assert circ.gates[0].params[0] == pytest.approx(0.0)
 
-        circ.set_params({0: [0.3]})
+        circ.set_params({"theta": 0.3})
+        assert circ.qasm3_symbols == {"theta": 0.3}
         assert_allclose(
             np.asarray(circ.psi["GATE_0"].data),
             np.asarray(rx_gate_param_gen((0.3,))),
@@ -260,6 +261,30 @@ class TestCircuit:
         ]
         assert circ.qasm3_expressions[2][0] == "theta"
 
+    def test_openqasm3_named_param_binding_and_copy(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        input float theta;
+        qubit[2] q;
+        rx(theta) q[0];
+        ry(theta / 2) q[1];
+        """
+        )
+        circ2 = circ.copy()
+
+        assert circ2.qasm3_inputs == ("theta",)
+        assert circ2.qasm3_symbols == {"theta": "theta"}
+        assert circ2.qasm3_expressions == {
+            0: ("theta",),
+            1: ("(theta / 2)",),
+        }
+
+        circ2.set_params({"theta": 0.6})
+        assert circ2.gates[0].params == (pytest.approx(0.6),)
+        assert circ2.gates[1].params == (pytest.approx(0.3),)
+
     def test_openqasm3_broadcast_registers(self):
         circ = qtn.Circuit.from_openqasm3_str(
             """
@@ -290,6 +315,20 @@ class TestCircuit:
             """
         )
         assert circ.gates[0].params == (pytest.approx(math.pi / 2),)
+
+    def test_openqasm3_named_binding_requires_all_inputs(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            input float theta;
+            input float phi;
+            qubit[1] q;
+            u3(theta, phi, 0.0) q[0];
+            """
+        )
+        with pytest.raises(ValueError, match="Missing QASM 3 input values"):
+            circ.set_params({"theta": 0.2})
 
     def test_openqasm3_output_decl_unsupported(self):
         with pytest.raises(NotImplementedError, match="Output declarations"):

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -13,12 +13,6 @@ from quimb.tensor.circuit import (
     parse_openqasm3_url,
     rx_gate_param_gen,
 )
-
-
-def assert_warning_messages(record, messages):
-    assert [str(w.message) for w in record] == list(messages)
-
-
 def assert_same_gates(circ_a, circ_b):
     assert len(circ_a.gates) == len(circ_b.gates)
     for gate_a, gate_b in zip(circ_a.gates, circ_b.gates):
@@ -202,27 +196,21 @@ class TestCircuit:
     def test_from_openqasm2(self):
         with pytest.warns(SyntaxWarning) as record:
             qc = qtn.Circuit.from_openqasm2_str(example_openqasm2_qft())
-        assert_warning_messages(
-            record,
-            (
-                "Unsupported operation ignored: creg",
-                "Unsupported operation ignored: barrier",
-                "Unsupported operation ignored: measure",
-            ),
-        )
+        assert [str(w.message) for w in record] == [
+            "Unsupported operation ignored: creg",
+            "Unsupported operation ignored: barrier",
+            "Unsupported operation ignored: measure",
+        ]
         assert (qc.psi.H & qc.psi) ^ all == pytest.approx(1.0)
 
     def test_from_openqasm3(self):
         with pytest.warns(SyntaxWarning) as record:
             qc = qtn.Circuit.from_openqasm3_str(example_openqasm3_qft())
-        assert_warning_messages(
-            record,
-            (
-                "Unsupported operation ignored: bit",
-                "Unsupported operation ignored: barrier",
-                "Unsupported operation ignored: measure",
-            ),
-        )
+        assert [str(w.message) for w in record] == [
+            "Unsupported operation ignored: bit",
+            "Unsupported operation ignored: barrier",
+            "Unsupported operation ignored: measure",
+        ]
         assert (qc.psi.H & qc.psi) ^ all == pytest.approx(1.0)
 
     def test_openqasm2_openqasm3_shared_subset_match(self):
@@ -522,13 +510,10 @@ class TestCircuit:
                 x q[0];
                 """
             )
-        assert_warning_messages(
-            record,
-            (
-                "Unsupported operation ignored: bit",
-                "Unsupported operation ignored: measure",
-            ),
-        )
+        assert [str(w.message) for w in record] == [
+            "Unsupported operation ignored: bit",
+            "Unsupported operation ignored: measure",
+        ]
         assert [g.label for g in circ.gates] == ["X"]
 
     def test_openqasm3_measure_decl_initializer_warns(self):
@@ -542,10 +527,9 @@ class TestCircuit:
                 x q[0];
                 """
             )
-        assert_warning_messages(
-            record,
-            ("Unsupported operation ignored: measure",),
-        )
+        assert [str(w.message) for w in record] == [
+            "Unsupported operation ignored: measure"
+        ]
         assert [g.label for g in circ.gates] == ["X"]
 
     def test_openqasm3_custom_gates_overlapping_names(self):

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -13,12 +13,19 @@ from quimb.tensor.circuit import (
     parse_openqasm3_url,
     rx_gate_param_gen,
 )
+from quimb.tensor.interface import pack, unpack
+
+
 def assert_same_gates(circ_a, circ_b):
     assert len(circ_a.gates) == len(circ_b.gates)
     for gate_a, gate_b in zip(circ_a.gates, circ_b.gates):
         assert gate_a.label == gate_b.label
         assert tuple(gate_a.qubits) == tuple(gate_b.qubits)
-        assert tuple(gate_a.params) == pytest.approx(tuple(gate_b.params))
+        assert len(gate_a.params) == len(gate_b.params)
+        for pa, pb in zip(gate_a.params, gate_b.params):
+            if np.isnan(pa) and np.isnan(pb):
+                continue
+            assert pa == pytest.approx(pb)
 
 
 def rand_reg_graph(reg, n, seed=None):
@@ -230,14 +237,14 @@ class TestCircuit:
         rx(theta) q[0];
         """
         circ = qtn.Circuit.from_openqasm3_str(qasm_str)
-        assert circ.qasm3_inputs == ("theta",)
-        assert circ.qasm3_symbols == {"theta": "theta"}
-        assert circ.qasm3_expressions == {0: ("theta",)}
+        assert circ.named_param_names == ("theta",)
+        assert np.isnan(circ.named_params["theta"])
+        assert circ.param_expressions == {0: ("theta",)}
         assert circ.gates[0].label == "RX"
-        assert circ.gates[0].params[0] == pytest.approx(0.0)
+        assert math.isnan(circ.gates[0].params[0])
 
         circ.set_params({"theta": 0.3})
-        assert circ.qasm3_symbols == {"theta": 0.3}
+        assert circ.named_params["theta"] == pytest.approx(0.3)
         assert_allclose(
             np.asarray(circ.psi["GATE_0"].data),
             np.asarray(rx_gate_param_gen((0.3,))),
@@ -269,7 +276,7 @@ class TestCircuit:
             "CX",
             "U3",
         ]
-        assert circ.qasm3_expressions[2][0] == "theta"
+        assert circ.param_expressions[2][0] == "theta"
 
     def test_openqasm3_named_param_binding_and_copy(self):
         circ = qtn.Circuit.from_openqasm3_str(
@@ -284,9 +291,9 @@ class TestCircuit:
         )
         circ2 = circ.copy()
 
-        assert circ2.qasm3_inputs == ("theta",)
-        assert circ2.qasm3_symbols == {"theta": "theta"}
-        assert circ2.qasm3_expressions == {
+        assert circ2.named_param_names == ("theta",)
+        assert np.isnan(circ2.named_params["theta"])
+        assert circ2.param_expressions == {
             0: ("theta",),
             1: ("(theta / 2)",),
         }
@@ -294,9 +301,9 @@ class TestCircuit:
         circ2.set_params({"theta": 0.6})
         assert circ2.gates[0].params == (pytest.approx(0.6),)
         assert circ2.gates[1].params == (pytest.approx(0.3),)
-        assert circ.gates[0].params == (pytest.approx(0.0),)
-        assert circ.gates[1].params == (pytest.approx(0.0),)
-        assert circ.qasm3_symbols == {"theta": "theta"}
+        assert math.isnan(circ.gates[0].params[0])
+        assert math.isnan(circ.gates[1].params[0])
+        assert np.isnan(circ.named_params["theta"])
 
         circ2.set_params({"theta": 0.2})
         assert circ2.gates[0].params == (pytest.approx(0.2),)
@@ -387,22 +394,22 @@ class TestCircuit:
         assert_same_gates(circ_str, circ_file)
         assert_same_gates(circ_str, circ_url)
         assert (
-            circ_file.qasm3_inputs
-            == circ_str.qasm3_inputs
-            == circ_url.qasm3_inputs
+            circ_file.named_param_names
+            == circ_str.named_param_names
+            == circ_url.named_param_names
         )
         assert (
-            circ_file.qasm3_symbols
-            == circ_str.qasm3_symbols
-            == circ_url.qasm3_symbols
+            set(circ_file.named_params)
+            == set(circ_str.named_params)
+            == set(circ_url.named_params)
         )
         assert (
-            circ_file.qasm3_expressions
-            == circ_str.qasm3_expressions
-            == circ_url.qasm3_expressions
+            circ_file.param_expressions
+            == circ_str.param_expressions
+            == circ_url.param_expressions
         )
 
-    def test_openqasm3_named_binding_requires_all_inputs(self):
+    def test_openqasm3_named_binding_supports_partial_updates(self):
         circ = qtn.Circuit.from_openqasm3_str(
             """
             OPENQASM 3.0;
@@ -413,10 +420,15 @@ class TestCircuit:
             u3(theta, phi, 0.0) q[0];
             """
         )
-        with pytest.raises(ValueError, match="Missing QASM 3 input values"):
-            circ.set_params({"theta": 0.2})
+        circ.set_params({"theta": 0.2})
+        assert circ.gates[0].params[0] == pytest.approx(0.2)
+        assert math.isnan(circ.gates[0].params[1])
+        assert circ.gates[0].params[2] == pytest.approx(0.0)
 
-    def test_openqasm3_named_binding_empty_dict_requires_inputs(self):
+        circ.set_params({"phi": 0.4})
+        assert tuple(circ.gates[0].params) == pytest.approx((0.2, 0.4, 0.0))
+
+    def test_openqasm3_named_binding_empty_dict_preserves_state(self):
         circ = qtn.Circuit.from_openqasm3_str(
             """
             OPENQASM 3.0;
@@ -426,8 +438,8 @@ class TestCircuit:
             rx(theta) q[0];
             """
         )
-        with pytest.raises(ValueError, match="Missing QASM 3 input values"):
-            circ.set_params({})
+        circ.set_params({})
+        assert math.isnan(circ.gates[0].params[0])
 
     def test_openqasm3_array_index_symbolic_binding(self):
         circ = qtn.Circuit.from_openqasm3_str(
@@ -441,7 +453,7 @@ class TestCircuit:
             ry(angles[1]) q[1];
             """
         )
-        assert circ.qasm3_expressions == {
+        assert circ.param_expressions == {
             0: ("theta",),
             1: ("(theta / 2)",),
         }
@@ -460,10 +472,67 @@ class TestCircuit:
             rx(theta) q[0];
             """
         )
-        with pytest.raises(ValueError, match="Unknown QASM 3 input values"):
+        with pytest.raises(ValueError, match="Unknown named parameter values"):
             circ.set_params({"theta": 0.2, "phi": 0.3})
 
-    def test_openqasm3_named_binding_rejects_mixed_keys(self):
+    def test_openqasm3_named_binding_accepts_mixed_keys(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            input float theta;
+            qubit[2] q;
+            rx(theta) q[0];
+            """
+        )
+        circ.u3(0.1, 0.2, 0.3, 1, parametrize=True)
+        circ.set_params({"theta": 0.2, 1: (0.4, 0.5, 0.6)})
+        assert tuple(circ.gates[0].params) == pytest.approx((0.2,))
+        assert tuple(circ.gates[1].params) == pytest.approx((0.4, 0.5, 0.6))
+
+    def test_openqasm3_get_set_params_roundtrip(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            input float theta;
+            qubit[2] q;
+            rx(theta) q[0];
+            """
+        )
+        circ.u3(0.1, 0.2, 0.3, 1, parametrize=True)
+        circ.set_params({"theta": 0.2, 1: (0.4, 0.5, 0.6)})
+
+        params = circ.get_params()
+        assert params["theta"] == pytest.approx(0.2)
+        assert tuple(params[1]) == pytest.approx((0.4, 0.5, 0.6))
+
+        circ2 = circ.copy()
+        circ2.set_params(params)
+        assert tuple(circ2.gates[0].params) == pytest.approx((0.2,))
+        assert tuple(circ2.gates[1].params) == pytest.approx((0.4, 0.5, 0.6))
+
+    def test_openqasm3_named_params_pack_unpack_roundtrip(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            input float theta;
+            qubit[1] q;
+            rx(cos(theta / 2)) q[0];
+            """
+        )
+        circ.set_params({"theta": np.array(0.6)})
+
+        params, skeleton = pack(circ)
+        assert params["theta"] == pytest.approx(0.6)
+
+        circ2 = unpack({"theta": np.array(0.2)}, skeleton)
+        assert tuple(circ2.gates[0].params) == pytest.approx(
+            (math.cos(0.1),)
+        )
+
+    def test_openqasm3_named_binding_rejects_direct_managed_gate_override(self):
         circ = qtn.Circuit.from_openqasm3_str(
             """
             OPENQASM 3.0;
@@ -474,9 +543,27 @@ class TestCircuit:
             """
         )
         with pytest.raises(
-            TypeError, match="all gate indices or all QASM 3 input names"
+            ValueError, match="managed by named parameter expressions"
         ):
             circ.set_params({"theta": 0.2, 0: (0.1,)})
+
+    def test_circuit_register_named_params_generic(self):
+        circ = qtn.Circuit(2)
+        circ.rx(np.nan, 0, parametrize=True)
+        circ.ry(np.nan, 1, parametrize=True)
+        circ.register_named_params(
+            {"theta": np.nan},
+            {
+                0: ("theta",),
+                1: ("cos(theta / 2)",),
+            },
+        )
+
+        circ.set_params({"theta": np.array(0.6)})
+        assert tuple(circ.gates[0].params) == pytest.approx((0.6,))
+        assert tuple(circ.gates[1].params) == pytest.approx(
+            (math.cos(0.3),)
+        )
 
     def test_openqasm3_output_decl_unsupported(self):
         with pytest.raises(NotImplementedError, match="Output declarations"):
@@ -547,7 +634,7 @@ class TestCircuit:
             foo(0.1, a) q[0];
             """
         )
-        assert circ.qasm3_expressions == {0: ("a", 0.1, "a")}
+        assert circ.param_expressions == {0: ("a", 0.1, "a")}
         circ.set_params({"a": 0.2})
         assert tuple(circ.gates[0].params) == pytest.approx((0.2, 0.1, 0.2))
 

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -411,7 +411,9 @@ class TestCircuit:
             rx(theta) q[0];
             """
         )
-        with pytest.raises(TypeError, match="all gate indices or all QASM 3 input names"):
+        with pytest.raises(
+            TypeError, match="all gate indices or all QASM 3 input names"
+        ):
             circ.set_params({"theta": 0.2, 0: (0.1,)})
 
     def test_openqasm3_output_decl_unsupported(self):

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -7,7 +7,12 @@ from numpy.testing import assert_allclose
 
 import quimb as qu
 import quimb.tensor as qtn
-from quimb.tensor.circuit import rx_gate_param_gen
+from quimb.tensor.circuit import (
+    parse_openqasm3_file,
+    parse_openqasm3_str,
+    parse_openqasm3_url,
+    rx_gate_param_gen,
+)
 
 
 def assert_warning_messages(record, messages):
@@ -339,6 +344,75 @@ class TestCircuit:
             """
         )
         assert circ.gates[0].params == (pytest.approx(math.pi / 2),)
+
+    def test_openqasm3_parse_file_and_url(self, tmp_path):
+        qasm_str = """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        input float theta;
+        qubit[2] q;
+        rx(theta) q[0];
+        cx q[0], q[1];
+        """
+        qasm_file = tmp_path / "example.qasm"
+        qasm_file.write_text(qasm_str)
+
+        info_str = parse_openqasm3_str(qasm_str)
+        info_file = parse_openqasm3_file(qasm_file)
+        info_url = parse_openqasm3_url(qasm_file.as_uri())
+
+        assert info_file["n"] == info_str["n"] == info_url["n"]
+        assert (
+            info_file["n_gates"] == info_str["n_gates"] == info_url["n_gates"]
+        )
+        assert info_file["inputs"] == info_str["inputs"] == info_url["inputs"]
+        assert (
+            info_file["symbols"] == info_str["symbols"] == info_url["symbols"]
+        )
+        assert (
+            info_file["expressions"]
+            == info_str["expressions"]
+            == info_url["expressions"]
+        )
+        for parsed in (info_file, info_url):
+            assert_same_gates(
+                qtn.Circuit.from_gates(info_str["gates"], N=info_str["n"]),
+                qtn.Circuit.from_gates(parsed["gates"], N=parsed["n"]),
+            )
+
+    def test_openqasm3_circuit_from_file_and_url(self, tmp_path):
+        qasm_str = """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        input float theta;
+        qubit[2] q;
+        rx(theta) q[0];
+        cx q[0], q[1];
+        """
+        qasm_file = tmp_path / "example.qasm"
+        qasm_file.write_text(qasm_str)
+
+        circ_str = qtn.Circuit.from_openqasm3_str(qasm_str)
+        circ_file = qtn.Circuit.from_openqasm3_file(qasm_file)
+        circ_url = qtn.Circuit.from_openqasm3_url(qasm_file.as_uri())
+
+        assert_same_gates(circ_str, circ_file)
+        assert_same_gates(circ_str, circ_url)
+        assert (
+            circ_file.qasm3_inputs
+            == circ_str.qasm3_inputs
+            == circ_url.qasm3_inputs
+        )
+        assert (
+            circ_file.qasm3_symbols
+            == circ_str.qasm3_symbols
+            == circ_url.qasm3_symbols
+        )
+        assert (
+            circ_file.qasm3_expressions
+            == circ_str.qasm3_expressions
+            == circ_url.qasm3_expressions
+        )
 
     def test_openqasm3_named_binding_requires_all_inputs(self):
         circ = qtn.Circuit.from_openqasm3_str(

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -14,6 +14,14 @@ def assert_warning_messages(record, messages):
     assert [str(w.message) for w in record] == list(messages)
 
 
+def assert_same_gates(circ_a, circ_b):
+    assert len(circ_a.gates) == len(circ_b.gates)
+    for gate_a, gate_b in zip(circ_a.gates, circ_b.gates):
+        assert gate_a.label == gate_b.label
+        assert tuple(gate_a.qubits) == tuple(gate_b.qubits)
+        assert tuple(gate_a.params) == pytest.approx(tuple(gate_b.params))
+
+
 def rand_reg_graph(reg, n, seed=None):
     import networkx as nx
 
@@ -205,11 +213,20 @@ class TestCircuit:
         assert_warning_messages(
             record,
             (
+                "Unsupported operation ignored: bit",
                 "Unsupported operation ignored: barrier",
                 "Unsupported operation ignored: measure",
             ),
         )
         assert (qc.psi.H & qc.psi) ^ all == pytest.approx(1.0)
+
+    def test_openqasm2_openqasm3_shared_subset_match(self):
+        with pytest.warns(SyntaxWarning):
+            circ2 = qtn.Circuit.from_openqasm2_str(example_openqasm2_qft())
+        with pytest.warns(SyntaxWarning):
+            circ3 = qtn.Circuit.from_openqasm3_str(example_openqasm3_qft())
+        assert_same_gates(circ2, circ3)
+        assert_allclose(circ2.psi.to_dense(), circ3.psi.to_dense())
 
     def test_openqasm3_symbolic_params(self):
         qasm_str = """
@@ -330,6 +347,66 @@ class TestCircuit:
         with pytest.raises(ValueError, match="Missing QASM 3 input values"):
             circ.set_params({"theta": 0.2})
 
+    def test_openqasm3_named_binding_empty_dict_requires_inputs(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            input float theta;
+            qubit[1] q;
+            rx(theta) q[0];
+            """
+        )
+        with pytest.raises(ValueError, match="Missing QASM 3 input values"):
+            circ.set_params({})
+
+    def test_openqasm3_array_index_symbolic_binding(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            input float theta;
+            array[float, 2] angles = {theta, theta / 2};
+            qubit[2] q;
+            rx(angles[0]) q[0];
+            ry(angles[1]) q[1];
+            """
+        )
+        assert circ.qasm3_expressions == {
+            0: ("theta",),
+            1: ("(theta / 2)",),
+        }
+
+        circ.set_params({"theta": 0.6})
+        assert tuple(circ.gates[0].params) == pytest.approx((0.6,))
+        assert tuple(circ.gates[1].params) == pytest.approx((0.3,))
+
+    def test_openqasm3_named_binding_rejects_unknown_inputs(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            input float theta;
+            qubit[1] q;
+            rx(theta) q[0];
+            """
+        )
+        with pytest.raises(ValueError, match="Unknown QASM 3 input values"):
+            circ.set_params({"theta": 0.2, "phi": 0.3})
+
+    def test_openqasm3_named_binding_rejects_mixed_keys(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            input float theta;
+            qubit[1] q;
+            rx(theta) q[0];
+            """
+        )
+        with pytest.raises(TypeError, match="all gate indices or all QASM 3 input names"):
+            circ.set_params({"theta": 0.2, 0: (0.1,)})
+
     def test_openqasm3_output_decl_unsupported(self):
         with pytest.raises(NotImplementedError, match="Output declarations"):
             qtn.Circuit.from_openqasm3_str(
@@ -349,6 +426,163 @@ class TestCircuit:
                 reset q[0];
                 """
             )
+
+    def test_openqasm3_measure_assignment_warns(self):
+        with pytest.warns(SyntaxWarning) as record:
+            circ = qtn.Circuit.from_openqasm3_str(
+                """
+                OPENQASM 3.0;
+                include "stdgates.inc";
+                qubit[1] q;
+                bit c;
+                c = measure q[0];
+                x q[0];
+                """
+            )
+        assert_warning_messages(
+            record,
+            (
+                "Unsupported operation ignored: bit",
+                "Unsupported operation ignored: measure",
+            ),
+        )
+        assert [g.label for g in circ.gates] == ["X"]
+
+    def test_openqasm3_custom_gates_overlapping_names(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            input float a;
+            qubit[1] q;
+
+            gate foo(a, aa) q {
+                u3(aa, a, aa) q;
+            }
+
+            foo(0.1, a) q[0];
+            """
+        )
+        assert circ.qasm3_expressions == {0: ("a", 0.1, "a")}
+        circ.set_params({"a": 0.2})
+        assert tuple(circ.gates[0].params) == pytest.approx((0.2, 0.1, 0.2))
+
+    def test_openqasm3_custom_gates_match_openqasm2(self):
+        circ2 = qtn.Circuit.from_openqasm2_str(
+            """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[3];
+
+        gate hello a, b {
+            h a;
+            cx a, b;
+            u3(0.1, 0.2, 0.3) b;
+        }
+
+        gate world(param1, theta) q {
+            u2(theta / 2, param1) q;
+            u2(param1, theta / 2) q;
+        }
+
+        hello q[0], q[1];
+        world(0.1, 0.2) q[2];
+        hello q[2], q[1];
+        """
+        )
+        circ3 = qtn.Circuit.from_openqasm3_str(
+            """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qubit[3] q;
+
+        gate hello a, b {
+            h a;
+            cx a, b;
+            u3(0.1, 0.2, 0.3) b;
+        }
+
+        gate world(param1, theta) q {
+            u2(theta / 2, param1) q;
+            u2(param1, theta / 2) q;
+        }
+
+        hello q[0], q[1];
+        world(0.1, 0.2) q[2];
+        hello q[2], q[1];
+        """
+        )
+        assert_same_gates(circ2, circ3)
+
+    def test_openqasm3_nested_custom_gates_match_openqasm2(self):
+        circ2 = qtn.Circuit.from_openqasm2_str(
+            """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[3];
+
+        gate cphase(theta) a, b {
+            U3(0, 0, theta / 2) a;
+            CX a, b;
+            U3(0, 0, -theta / 2) b;
+            CX a, b;
+            U3(0, 0, theta / 2) b;
+        }
+
+        gate doublecphase(theta) a, b, c {
+            cphase(theta) a, b;
+            cphase(theta) b, c;
+        }
+
+        doublecphase(0.1) q[0], q[1], q[2];
+        doublecphase(0.2) q[2], q[0], q[1];
+        """
+        )
+        circ3 = qtn.Circuit.from_openqasm3_str(
+            """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qubit[3] q;
+
+        gate cphase(theta) a, b {
+            U3(0, 0, theta / 2) a;
+            CX a, b;
+            U3(0, 0, -theta / 2) b;
+            CX a, b;
+            U3(0, 0, theta / 2) b;
+        }
+
+        gate doublecphase(theta) a, b, c {
+            cphase(theta) a, b;
+            cphase(theta) b, c;
+        }
+
+        doublecphase(0.1) q[0], q[1], q[2];
+        doublecphase(0.2) q[2], q[0], q[1];
+        """
+        )
+        assert_same_gates(circ2, circ3)
+
+    def test_openqasm3_gate_name_match_openqasm2(self):
+        circ2 = qtn.Circuit.from_openqasm2_str(
+            """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        gate gate_PauliEvolution(param0) q0,q1 { rz(0.2) q0; rz(-0.1) q1; }
+        qreg q[2];
+        gate_PauliEvolution(0.1) q[0],q[1];
+        """
+        )
+        circ3 = qtn.Circuit.from_openqasm3_str(
+            """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        gate gate_PauliEvolution(param0) q0,q1 { rz(0.2) q0; rz(-0.1) q1; }
+        qubit[2] q;
+        gate_PauliEvolution(0.1) q[0],q[1];
+        """
+        )
+        assert_same_gates(circ2, circ3)
 
     def test_openqasm2_custom_gates(self):
         circ = qtn.Circuit.from_openqasm2_str(

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -301,6 +301,13 @@ class TestCircuit:
         circ2.set_params({"theta": 0.6})
         assert circ2.gates[0].params == (pytest.approx(0.6),)
         assert circ2.gates[1].params == (pytest.approx(0.3),)
+        assert circ.gates[0].params == (pytest.approx(0.0),)
+        assert circ.gates[1].params == (pytest.approx(0.0),)
+        assert circ.qasm3_symbols == {"theta": "theta"}
+
+        circ2.set_params({"theta": 0.2})
+        assert circ2.gates[0].params == (pytest.approx(0.2),)
+        assert circ2.gates[1].params == (pytest.approx(0.1),)
 
     def test_openqasm3_broadcast_registers(self):
         circ = qtn.Circuit.from_openqasm3_str(
@@ -445,6 +452,23 @@ class TestCircuit:
                 "Unsupported operation ignored: bit",
                 "Unsupported operation ignored: measure",
             ),
+        )
+        assert [g.label for g in circ.gates] == ["X"]
+
+    def test_openqasm3_measure_decl_initializer_warns(self):
+        with pytest.warns(SyntaxWarning) as record:
+            circ = qtn.Circuit.from_openqasm3_str(
+                """
+                OPENQASM 3.0;
+                include "stdgates.inc";
+                qubit[1] q;
+                bit c = measure q[0];
+                x q[0];
+                """
+            )
+        assert_warning_messages(
+            record,
+            ("Unsupported operation ignored: measure",),
         )
         assert [g.label for g in circ.gates] == ["X"]
 

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -7,6 +7,11 @@ from numpy.testing import assert_allclose
 
 import quimb as qu
 import quimb.tensor as qtn
+from quimb.tensor.circuit import rx_gate_param_gen
+
+
+def assert_warning_messages(record, messages):
+    assert [str(w.message) for w in record] == list(messages)
 
 
 def rand_reg_graph(reg, n, seed=None):
@@ -125,6 +130,36 @@ def example_openqasm2_qft():
     """
 
 
+def example_openqasm3_qft():
+    return """
+    // quantum Fourier transform
+
+    OPENQASM 3.0;
+    include "stdgates.inc";
+
+    qubit[4] q;
+    bit[4] c;
+    x q[0];
+    x q[2];
+    barrier q;
+    h q[0];
+    cu1(pi/2) q[1], q[0];
+    h q[1];
+    cu1(pi/4) q[2], q[0];
+    cu1(pi/2) q[2], q[1];
+    /*
+    This is a multi line comment.
+    */
+    h q[2];
+    cu1(pi/8) q[3], q[0];
+    cu1(pi/4) q[3], q[1];
+    cu1(pi/2) q[3], q[2];
+    h q[3];
+
+    measure q -> c;
+    """
+
+
 class TestCircuit:
     def test_prepare_GHZ(self):
         qc = qtn.Circuit(3)
@@ -152,8 +187,129 @@ class TestCircuit:
         assert (qc.psi.H & qc.psi) ^ all == pytest.approx(1.0)
 
     def test_from_openqasm2(self):
-        qc = qtn.Circuit.from_openqasm2_str(example_openqasm2_qft())
+        with pytest.warns(SyntaxWarning) as record:
+            qc = qtn.Circuit.from_openqasm2_str(example_openqasm2_qft())
+        assert_warning_messages(
+            record,
+            (
+                "Unsupported operation ignored: creg",
+                "Unsupported operation ignored: barrier",
+                "Unsupported operation ignored: measure",
+            ),
+        )
         assert (qc.psi.H & qc.psi) ^ all == pytest.approx(1.0)
+
+    def test_from_openqasm3(self):
+        with pytest.warns(SyntaxWarning) as record:
+            qc = qtn.Circuit.from_openqasm3_str(example_openqasm3_qft())
+        assert_warning_messages(
+            record,
+            (
+                "Unsupported operation ignored: barrier",
+                "Unsupported operation ignored: measure",
+            ),
+        )
+        assert (qc.psi.H & qc.psi) ^ all == pytest.approx(1.0)
+
+    def test_openqasm3_symbolic_params(self):
+        qasm_str = """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        input float theta;
+        qubit[1] q;
+        rx(theta) q[0];
+        """
+        circ = qtn.Circuit.from_openqasm3_str(qasm_str)
+        assert circ.qasm3_inputs == ("theta",)
+        assert circ.qasm3_symbols == {"theta": "theta"}
+        assert circ.qasm3_expressions == {0: ("theta",)}
+        assert circ.gates[0].label == "RX"
+        assert circ.gates[0].params[0] == pytest.approx(0.0)
+
+        circ.set_params({0: [0.3]})
+        assert_allclose(
+            np.asarray(circ.psi["GATE_0"].data),
+            np.asarray(rx_gate_param_gen((0.3,))),
+        )
+
+    def test_openqasm3_custom_gates(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        input float theta;
+        qubit[3] q;
+
+        gate hello a, b {
+            h a;
+            cx a, b;
+            u3(theta, 0.2, 0.3) b;
+        }
+
+        hello q[0], q[1];
+        hello q[2], q[1];
+        """
+        )
+        assert [g.label for g in circ.gates] == [
+            "H",
+            "CX",
+            "U3",
+            "H",
+            "CX",
+            "U3",
+        ]
+        assert circ.qasm3_expressions[2][0] == "theta"
+
+    def test_openqasm3_broadcast_registers(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            qubit[3] q;
+            qubit[3] r;
+            h q;
+            cx q, r;
+            """
+        )
+        assert [(g.label, g.qubits) for g in circ.gates] == [
+            ("H", (0,)),
+            ("H", (1,)),
+            ("H", (2,)),
+            ("CX", (0, 3)),
+            ("CX", (1, 4)),
+            ("CX", (2, 5)),
+        ]
+
+    def test_openqasm3_numeric_parse(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            qubit[1] q;
+            rx(pi / 2) q[0];
+            """
+        )
+        assert circ.gates[0].params == (pytest.approx(math.pi / 2),)
+
+    def test_openqasm3_output_decl_unsupported(self):
+        with pytest.raises(NotImplementedError, match="Output declarations"):
+            qtn.Circuit.from_openqasm3_str(
+                """
+                OPENQASM 3.0;
+                output float theta;
+                qubit[1] q;
+                """
+            )
+
+    def test_openqasm3_unsupported_ops(self):
+        with pytest.raises(NotImplementedError):
+            qtn.Circuit.from_openqasm3_str(
+                """
+                OPENQASM 3.0;
+                qubit[1] q;
+                reset q[0];
+                """
+            )
 
     def test_openqasm2_custom_gates(self):
         circ = qtn.Circuit.from_openqasm2_str(

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -607,6 +607,62 @@ class TestCircuit:
         ):
             circ.set_params({"theta": 0.2})
 
+    def test_circuit_register_named_params_rejects_unknown_gate_index(self):
+        circ = qtn.Circuit(1)
+        circ.rx(np.nan, 0, parametrize=True)
+
+        with pytest.raises(ValueError, match="unknown gate index: 2"):
+            circ.register_named_params({"theta": np.nan}, {2: ("theta",)})
+
+    def test_circuit_register_named_params_rejects_non_parametrized_gate(self):
+        circ = qtn.Circuit(1)
+        circ.rx(0.1, 0)
+
+        with pytest.raises(
+            ValueError, match="got non-parametrized gate: 0"
+        ):
+            circ.register_named_params({"theta": np.nan}, {0: ("theta",)})
+
+    def test_circuit_register_named_params_rejects_wrong_arity(self):
+        circ = qtn.Circuit(1)
+        circ.rx(np.nan, 0, parametrize=True)
+
+        with pytest.raises(
+            ValueError, match="expected 1, got 2"
+        ):
+            circ.register_named_params(
+                {"theta": np.nan},
+                {0: ("theta", "theta")},
+            )
+
+    def test_circuit_register_named_params_accepts_generator_expressions(self):
+        circ = qtn.Circuit(1)
+        circ.rx(np.nan, 0, parametrize=True)
+        circ.register_named_params(
+            {"theta": np.nan},
+            {0: (expr for expr in ("theta",))},
+        )
+
+        circ.set_params({"theta": np.array(0.6)})
+        assert tuple(circ.gates[0].params) == pytest.approx((0.6,))
+
+    def test_circuit_apply_to_arrays_updates_named_params(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            input float theta;
+            qubit[1] q;
+            rx(theta / 2) q[0];
+            """
+        )
+        circ.set_params({"theta": np.array(0.6, dtype=np.float64)})
+
+        circ.apply_to_arrays(lambda x: np.asarray(x, dtype=np.float32))
+
+        assert circ.get_params()["theta"].dtype == np.float32
+        assert circ.psi["GATE_0"].params.dtype == np.float32
+
     def test_openqasm3_output_decl_unsupported(self):
         with pytest.raises(NotImplementedError, match="Output declarations"):
             qtn.Circuit.from_openqasm3_str(

--- a/tests/test_tensor/test_optimizers.py
+++ b/tests/test_tensor/test_optimizers.py
@@ -467,3 +467,34 @@ def test_optimize_circuit_directly(backend, simplify):
     assert circ_opt is not circ
     assert loss(circ_opt, H) < -0.74
     assert {t.backend for t in circ_opt.psi} == {"numpy"}
+
+
+@pytest.mark.parametrize("backend", [autograd_case])
+def test_optimize_named_param_circuit_directly(backend):
+    circ = qtn.Circuit.from_openqasm3_str(
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        input float theta;
+        qubit[1] q;
+        rx(theta / 2) q[0];
+        """
+    )
+    circ.set_params({"theta": np.array(0.2)})
+    target = np.array(0.8)
+
+    def loss(circ, target):
+        theta = circ.get_params()["theta"]
+        return (theta - target) ** 2
+
+    tnopt = qtn.TNOptimizer(
+        circ,
+        loss,
+        loss_constants=dict(target=target),
+        autodiff_backend=backend,
+    )
+    circ_opt = tnopt.optimize(20)
+
+    assert circ_opt is not circ
+    assert circ_opt.get_params()["theta"] == pytest.approx(0.8, abs=1e-3)
+    assert tuple(circ_opt.gates[0].params) == pytest.approx((0.4,), abs=1e-3)


### PR DESCRIPTION
Title
Add OpenQASM 3 import support for Circuit
Body
Closes #256.
Summary
OpenQASM 2 can't express parametrised circuits with unbound parameters. This PR adds an OpenQASM 3 import path to quimb.tensor.Circuit that supports a practical subset of the QASM3 spec, including symbolic/unbound parameters, so circuits can be parsed with free parameters and bound later.
It mirrors the existing OpenQASM 2 API surface (from_openqasm2_str/file/url, parse_openqasm2_str/file/url) so usage is familiar.
New public API

Circuit.from_openqasm3_str(contents, **circuit_opts)
Circuit.from_openqasm3_file(fname, **circuit_opts)
Circuit.from_openqasm3_url(url, **circuit_opts)
parse_openqasm3_str(contents)
parse_openqasm3_file(fname, **kwargs)
parse_openqasm3_url(url, **kwargs)

Supported QASM3 subset

qubit declarations (single and register), with register broadcast over gate applications
input declarations for unbound/symbolic parameters
const, classical, and array declarations, with expression evaluation (including array subscripts)
Standard gate applications with numeric and symbolic parameters
Custom gate definitions, including nested custom gates
Symbolic gate parameters carried through to the circuit

Symbolic parameter handling
QASM3 symbolic metadata is stored on the circuit:

qasm3_inputs — declared input names
qasm3_symbols — symbol table
qasm3_expressions — parsed expressions

Circuit.copy() and Circuit.set_params() were extended to preserve and rebind these symbolic parameters by input name. Rebinding rejects missing, unknown, or mixed named bindings cleanly so partial/incorrect binds fail loudly rather than silently producing a wrong circuit.
Edge-case fixes

Fixed token replacement during custom-gate expansion so overlapping symbol names no longer corrupt expressions.
Added array-subscript support in QASM3 expression evaluation.
measure used inside an assignment/declaration (e.g. bit c = measure q[0];) now warns and is ignored rather than being mis-parsed.

Explicitly unsupported (raises NotImplementedError)
output declarations, control flow, and reset are not yet supported and raise a clear NotImplementedError.
Tests
Added/expanded in tests/test_tensor/test_circuit.py:

QASM2/QASM3 shared-subset equivalence (QASM3 behaviour matched against equivalent QASM2 circuits where applicable)
Symbolic parameter import and rebinding
copy() isolation and repeated rebinding
Register broadcast
Numeric expression parsing
Array-index symbolic binding
Unknown/missing/mixed named-input validation
Unsupported output/reset handling
measure assignment and bit c = measure q[0] warning paths
Custom gates, nested custom gates, overlapping parameter names

Validation

pytest tests/test_tensor/test_circuit.py -k openqasm -q — passed
pytest tests/test_tensor/test_circuit.py -k "not conversions" -q — passed
Pre-existing torch test_conversions failures reproduce on a clean main, so they are unrelated to this branch.

AI Use Disclosure
Codex was used to help generate test, find edge cases, standardize documentation and speed up writing core functions. All code was reviewed by a human and validated with testing