### PR TITLE
Add basic OpenQASM 3 parsing support

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,14 @@ Release notes for `quimb`.
 
 **Enhancements:**
 
+- add OpenQASM 3 parsing support:
+  [`Circuit.from_openqasm3_str`](quimb.tensor.Circuit.from_openqasm3_str),
+  [`Circuit.from_openqasm3_file`](quimb.tensor.Circuit.from_openqasm3_file), and
+  [`Circuit.from_openqasm3_url`](quimb.tensor.Circuit.from_openqasm3_url),
+  covering basic gate/register/``const``/``let``/custom-gate functionality
+  comparable to the existing OpenQASM 2 parser, with clear errors for
+  unsupported features (control flow, gate modifiers, calibration blocks and
+  unbound ``input`` parameters) ({issue}`256`).
 - [`TensorNetwork.gauge_all_simple`](quimb.tensor.tensor_core.TensorNetwork.gauge_all_simple): add a ``fuse_multibonds`` option for updating gauges while preserving multi-index bonds, supported by explicit bond-index selection in [`tensor_compress_bond`](quimb.tensor.tensor_core.tensor_compress_bond).
 - add [`LatticeBondMap`](quimb.tensor.tnag.core.LatticeBondMap): helper for consistently assigning lattice bond indices across ordinary and periodic boundaries, use it in PEPS, PEPO, PEPS3D, scalar 2D/3D lattice tensor-network construction, and classical Ising tensor-network construction.
 - [`eigh_truncated`](quimb.tensor.decomp.eigh_truncated): add a ``shift`` option for optional diagonal regularization.

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -335,6 +335,397 @@ def parse_openqasm2_url(url, **kwargs):
     return parse_openqasm2_str(request.urlopen(url).read().decode(), **kwargs)
 
 
+@functools.lru_cache(None)
+def get_openqasm3_regexes():
+    return {
+        "header": re.compile(r"OPENQASM\s+3(?:\.0)?$", re.IGNORECASE),
+        "include": re.compile(r'include\s+"[^"]+"$', re.IGNORECASE),
+        "qreg": re.compile(
+            r"qubit\s*(?:\[(\d+)\])?\s+([A-Za-z_]\w*)$",
+            re.IGNORECASE,
+        ),
+        "classical": re.compile(
+            r"(?:bit|bool|int|uint|float|angle|complex|array|creg)\b",
+            re.IGNORECASE,
+        ),
+        "const": re.compile(
+            r"const\s+(?:float|angle|int|uint)\s+([A-Za-z_]\w*)\s*=\s*(.+)$",
+            re.IGNORECASE,
+        ),
+        "let": re.compile(r"let\s+([A-Za-z_]\w*)\s*=\s*(.+)$"),
+        "gate": re.compile(
+            r"([A-Za-z_]\w*)\s*(?:\((.*)\))?\s+(.+)$",
+            re.IGNORECASE,
+        ),
+        "gate_sig": re.compile(
+            r"gate\s+([A-Za-z_]\w*)\s*(?:\((.*)\))?\s+(.+)$",
+            re.IGNORECASE,
+        ),
+        "ignore": re.compile(r"^(?:barrier|reset|gphase)\b", re.IGNORECASE),
+        "measure": re.compile(r"(?:^|\s)measure(?:\s|$)", re.IGNORECASE),
+        "error": re.compile(
+            r"^(?:if|for|while|switch|def|defcal|cal|box|delay|stretch|"
+            r"duration|extern|input|output)\b",
+            re.IGNORECASE,
+        ),
+        # gate modifiers (``ctrl @``, ``ctrl(2) @``, ``inv @``, ``pow(2) @`` ...)
+        # always prefix the gate, so detect the modifier keyword followed by the
+        # ``@`` token regardless of any intervening argument list
+        "modifier": re.compile(
+            r"^(?:ctrl|negctrl|inv|pow)\b[^@]*@",
+            re.IGNORECASE,
+        ),
+    }
+
+
+OPENQASM3_GATE_ALIASES = {
+    "p": "PHASE",
+    "phase": "PHASE",
+    "cp": "CPHASE",
+    "u": "U3",
+}
+
+
+def _split_openqasm_statements(contents):
+    """Split OpenQASM input into semicolon/braced statements, stripping
+    comments. This is intentionally small and not a full grammar lexer.
+    """
+    statements = []
+    chars = []
+    in_string = False
+    in_line_comment = False
+    in_block_comment = False
+    i = 0
+
+    while i < len(contents):
+        c = contents[i]
+        c_next = contents[i + 1] if i + 1 < len(contents) else ""
+
+        if in_line_comment:
+            if c == "\n":
+                in_line_comment = False
+            i += 1
+            continue
+
+        if in_block_comment:
+            if (c == "*") and (c_next == "/"):
+                in_block_comment = False
+                i += 2
+            else:
+                i += 1
+            continue
+
+        if not in_string and (c == "/") and (c_next == "/"):
+            in_line_comment = True
+            i += 2
+            continue
+
+        if not in_string and (c == "/") and (c_next == "*"):
+            in_block_comment = True
+            i += 2
+            continue
+
+        if c == '"':
+            in_string = not in_string
+            chars.append(c)
+            i += 1
+            continue
+
+        if (not in_string) and c in ";{}":
+            statement = "".join(chars).strip()
+            if statement:
+                statements.append(statement)
+            if c in "{}":
+                statements.append(c)
+            chars.clear()
+            i += 1
+            continue
+
+        chars.append(c)
+        i += 1
+
+    statement = "".join(chars).strip()
+    if statement:
+        statements.append(statement)
+
+    return statements
+
+
+def _eval_openqasm3_param(expr, env):
+    expr = expr.replace("^", "**")
+    eval_globals = {
+        "__builtins__": {},
+        "pi": math.pi,
+        "tau": math.tau,
+        "e": math.e,
+        "sin": math.sin,
+        "cos": math.cos,
+        "tan": math.tan,
+        "asin": math.asin,
+        "acos": math.acos,
+        "atan": math.atan,
+        "exp": math.exp,
+        "ln": math.log,
+        "sqrt": math.sqrt,
+    }
+    try:
+        return eval(expr, eval_globals, env)
+    except NameError as exc:
+        raise NotImplementedError(
+            "OpenQASM 3 unbound parameters are not currently supported: "
+            f"{expr}"
+        ) from exc
+    except Exception as exc:
+        raise SyntaxError(f"Could not parse OpenQASM 3 parameter: {expr}") from exc
+
+
+def _openqasm3_gate_label(label):
+    return OPENQASM3_GATE_ALIASES.get(label.lower(), label.upper())
+
+
+def _resolve_openqasm3_operand(operand, sitemap, aliases, constants):
+    operand = aliases.get(operand, operand)
+    if operand in sitemap:
+        return sitemap[operand]
+
+    match = re.match(r"([A-Za-z_]\w*)\[(.+)\]$", operand)
+    if match:
+        name, index = match.groups()
+        index = int(_eval_openqasm3_param(index, constants))
+        operand = f"{name}[{index}]"
+        if operand in sitemap:
+            return sitemap[operand]
+
+    raise SyntaxError(f"Unknown OpenQASM 3 qubit operand: {operand}")
+
+
+def _parse_openqasm3_operands(operands, sitemap, aliases, constants):
+    sites = []
+    for operand in to_clean_list(operands, ","):
+        sites.append(
+            _resolve_openqasm3_operand(operand, sitemap, aliases, constants)
+        )
+
+    return tuple(sites)
+
+
+def _substitute_openqasm3_gate_body(gate_line, param_repl, qubit_repl):
+    """Substitute formal parameters and qubits into a single custom-gate body
+    line. The line is first split into its ``label``, ``params`` and
+    ``operands`` so that substitution only ever happens inside the parameter and
+    operand regions - never the gate label. This prevents a formal name that
+    coincides with a gate label (e.g. a parameter called ``h``, or a qubit
+    called ``cx``) from being mistaken for, or clobbering, an instruction.
+    Word-boundary matching is used so that one formal name is not substituted
+    inside another (e.g. ``x`` inside ``cx``).
+    """
+    match = get_openqasm3_regexes()["gate"].match(gate_line)
+    if not match:
+        # not a recognisable gate application; leave untouched and let the main
+        # parsing loop raise an informative error when it is re-encountered
+        return gate_line
+
+    glabel, gparams, goperands = match.groups()
+
+    def _sub(text, replacements):
+        for name, value in replacements.items():
+            text = re.sub(rf"\b{re.escape(name)}\b", value, text)
+        return text
+
+    goperands = _sub(goperands, qubit_repl)
+    if gparams is not None:
+        gparams = _sub(gparams, param_repl)
+        return f"{glabel}({gparams}) {goperands}"
+    return f"{glabel} {goperands}"
+
+
+def _parse_openqasm3_gate_statement(statement, sitemap, aliases, constants):
+    match = get_openqasm3_regexes()["gate"].match(statement)
+    if not match:
+        raise SyntaxError(f"{statement}")
+
+    label, params, operands = match.groups()
+    label = _openqasm3_gate_label(label)
+
+    if params:
+        params = tuple(
+            _eval_openqasm3_param(param, constants)
+            for param in to_clean_list(params, ",")
+        )
+    else:
+        params = ()
+
+    qubits = _parse_openqasm3_operands(operands, sitemap, aliases, constants)
+    return Gate(label, params, qubits)
+
+
+def parse_openqasm3_str(contents):
+    """Parse the string contents of an OpenQASM 3 file.
+
+    This parser supports basic circuit/gate functionality comparable to the
+    OpenQASM 2 parser. It is not a full OpenQASM 3 grammar implementation:
+    unsupported operations, including control flow, calibration blocks, gate
+    modifiers, and unbound ``input`` parameters, raise clear errors.
+
+    Notable current limitations:
+
+    - gate broadcasting over a whole register (e.g. ``h q;`` for a multi-qubit
+      register ``q``) is not supported - index individual qubits instead
+      (``h q[0];``). Single-qubit registers may be referenced by name.
+    - ``input`` (unbound / symbolic) parameters are not supported because the
+      gate pipeline cannot yet carry symbolic parameters; supply concrete or
+      ``const``-evaluable values instead.
+    - global phase (``gphase``) is ignored with a warning as it does not affect
+      measurement outcomes.
+    """
+    rgxs = get_openqasm3_regexes()
+    statements = _split_openqasm_statements(contents)
+
+    sitemap = {}
+    aliases = {}
+    constants = {}
+    gates = []
+    custom_gates = {}
+    warned = {}
+
+    i = 0
+    while i < len(statements):
+        statement = statements[i].strip()
+        i += 1
+
+        if statement in "{}":
+            raise SyntaxError(f"Unexpected OpenQASM 3 block delimiter: {statement}")
+
+        if rgxs["header"].match(statement):
+            continue
+
+        if rgxs["include"].match(statement):
+            continue
+
+        match = rgxs["qreg"].match(statement)
+        if match:
+            nq, name = match.groups()
+            nq = int(nq) if nq is not None else 1
+            for j in range(nq):
+                sitemap[f"{name}[{j}]"] = len(sitemap)
+            if nq == 1:
+                aliases[name] = f"{name}[0]"
+            continue
+
+        match = rgxs["const"].match(statement)
+        if match:
+            name, expr = match.groups()
+            constants[name] = _eval_openqasm3_param(expr, constants)
+            continue
+
+        match = rgxs["let"].match(statement)
+        if match:
+            name, operand = match.groups()
+            aliases[name] = operand.strip()
+            continue
+
+        if statement.lower().startswith("gate "):
+            gate_sig = statement
+            if (i >= len(statements)) or (statements[i] != "{"):
+                raise SyntaxError(
+                    "OpenQASM 3 gate definitions must be followed by a block."
+                )
+            i += 1
+
+            gate_body = []
+            while i < len(statements):
+                statement = statements[i]
+                i += 1
+                if statement == "}":
+                    break
+                gate_body.append(statement)
+            else:
+                raise SyntaxError("Unterminated OpenQASM 3 gate definition.")
+
+            match = rgxs["gate_sig"].match(gate_sig)
+            if not match:
+                raise SyntaxError(f"{gate_sig}")
+
+            label, sig_params, sig_qubits = match.groups()
+            custom_gates[label] = (
+                to_clean_list(sig_params, ","),
+                to_clean_list(sig_qubits, ","),
+                gate_body,
+            )
+            continue
+
+        if rgxs["error"].match(statement) or rgxs["modifier"].match(statement):
+            raise NotImplementedError(
+                f"The following OpenQASM 3 instruction is not supported: "
+                f"{statement}"
+            )
+
+        if rgxs["ignore"].match(statement) or rgxs["measure"].search(statement):
+            op = "measure" if rgxs["measure"].search(statement) else statement.split()[0]
+            if not warned.get(op, False):
+                warnings.warn(
+                    f"Unsupported OpenQASM 3 operation ignored: {op}",
+                    SyntaxWarning,
+                )
+                warned[op] = True
+            continue
+
+        if rgxs["classical"].match(statement):
+            continue
+
+        match = rgxs["gate"].match(statement)
+        if match:
+            label, params, operands = match.groups()
+
+            if label in custom_gates:
+                sig_params, sig_qubits, gate_body = custom_gates[label]
+                param_repl = dict(
+                    zip(sig_params, to_clean_list(params, ","))
+                )
+                qubit_repl = dict(
+                    zip(sig_qubits, to_clean_list(operands, ","))
+                )
+                # recurse by prepending the translated gate body, substituting
+                # only within parameter/operand regions (never the gate label)
+                for gate_line in reversed(gate_body):
+                    statements.insert(
+                        i,
+                        _substitute_openqasm3_gate_body(
+                            gate_line, param_repl, qubit_repl
+                        ),
+                    )
+                continue
+
+            gates.append(
+                _parse_openqasm3_gate_statement(
+                    statement, sitemap, aliases, constants
+                )
+            )
+            continue
+
+        raise SyntaxError(f"{statement}")
+
+    return {
+        "n": len(sitemap),
+        "sitemap": sitemap,
+        "gates": gates,
+        "n_gates": len(gates),
+    }
+
+
+def parse_openqasm3_file(fname, **kwargs):
+    """Parse an OpenQASM 3 file."""
+    with open(fname) as f:
+        return parse_openqasm3_str(f.read(), **kwargs)
+
+
+def parse_openqasm3_url(url, **kwargs):
+    """Parse an OpenQASM 3 url."""
+    from urllib import request
+
+    return parse_openqasm3_str(request.urlopen(url).read().decode(), **kwargs)
+
+
 # -------------------------- core gate functions ---------------------------- #
 
 
@@ -1890,6 +2281,30 @@ class Circuit:
     def from_openqasm2_url(cls, url, progbar=False, **circuit_opts):
         """Generate a ``Circuit`` instance from an OpenQASM 2.0 url."""
         info = parse_openqasm2_url(url)
+        qc = cls(info["n"], **circuit_opts)
+        qc.apply_gates(info["gates"], progbar=progbar)
+        return qc
+
+    @classmethod
+    def from_openqasm3_str(cls, contents, progbar=False, **circuit_opts):
+        """Generate a ``Circuit`` instance from an OpenQASM 3 string."""
+        info = parse_openqasm3_str(contents)
+        qc = cls(info["n"], **circuit_opts)
+        qc.apply_gates(info["gates"], progbar=progbar)
+        return qc
+
+    @classmethod
+    def from_openqasm3_file(cls, fname, progbar=False, **circuit_opts):
+        """Generate a ``Circuit`` instance from an OpenQASM 3 file."""
+        info = parse_openqasm3_file(fname)
+        qc = cls(info["n"], **circuit_opts)
+        qc.apply_gates(info["gates"], progbar=progbar)
+        return qc
+
+    @classmethod
+    def from_openqasm3_url(cls, url, progbar=False, **circuit_opts):
+        """Generate a ``Circuit`` instance from an OpenQASM 3 url."""
+        info = parse_openqasm3_url(url)
         qc = cls(info["n"], **circuit_opts)
         qc.apply_gates(info["gates"], progbar=progbar)
         return qc

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -125,6 +125,36 @@ def example_openqasm2_qft():
     """
 
 
+def example_openqasm3_qft():
+    return """
+    // quantum Fourier transform
+
+    OPENQASM 3.0;
+    include "stdgates.inc";
+
+    qubit[4] q;
+    bit[4] c;
+    x q[0];
+    x q[2];
+    barrier q;
+    h q[0];
+    cp(pi / 2) q[1], q[0];
+    h q[1];
+    cp(pi / 4) q[2], q[0];
+    cp(pi / 2) q[2], q[1];
+    /*
+    This is a multi line comment.
+    */
+    h q[2];
+    cp(pi / 8) q[3], q[0];
+    cp(pi / 4) q[3], q[1];
+    cp(pi / 2) q[3], q[2];
+    h q[3];
+
+    c = measure q;
+    """
+
+
 class TestCircuit:
     def test_prepare_GHZ(self):
         qc = qtn.Circuit(3)
@@ -154,6 +184,43 @@ class TestCircuit:
     def test_from_openqasm2(self):
         qc = qtn.Circuit.from_openqasm2_str(example_openqasm2_qft())
         assert (qc.psi.H & qc.psi) ^ all == pytest.approx(1.0)
+
+    def test_from_openqasm3(self):
+        qc = qtn.Circuit.from_openqasm3_str(example_openqasm3_qft())
+        assert (qc.psi.H & qc.psi) ^ all == pytest.approx(1.0)
+        assert [g.label for g in qc.gates] == [
+            "X",
+            "X",
+            "H",
+            "CPHASE",
+            "H",
+            "CPHASE",
+            "CPHASE",
+            "H",
+            "CPHASE",
+            "CPHASE",
+            "CPHASE",
+            "H",
+        ]
+
+    def test_openqasm3_stdgate_aliases_and_constants(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+        OPENQASM 3;
+        include "stdgates.inc";
+        const float theta = pi / 3;
+        const int i = 0;
+        qubit[2] q;
+        let a = q[i];
+        U(theta, theta / 2, -theta) a;
+        p(pi / 7) q[1];
+        cp(theta) q[0], q[1];
+        """
+        )
+        assert [g.label for g in circ.gates] == ["U3", "PHASE", "CPHASE"]
+        assert circ.gates[0].params[0] == pytest.approx(np.pi / 3)
+        assert circ.gates[0].qubits == (0,)
+        assert circ.gates[2].qubits == (0, 1)
 
     def test_openqasm2_custom_gates(self):
         circ = qtn.Circuit.from_openqasm2_str(
@@ -233,6 +300,127 @@ class TestCircuit:
         """
         circ = qtn.Circuit.from_openqasm2_str(qasm_str)
         assert len(circ.gates) == 2
+
+    def test_openqasm3_custom_gates(self):
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+        OPENQASM 3;
+        include "stdgates.inc";
+        qubit[3] q;
+
+        gate hello a, b {
+            h a;
+            cx a, b;
+            U(0.1, 0.2, 0.3) b;
+        }
+
+        gate world(param1, theta) q {
+            p(theta / 2) q;
+            p(param1) q;
+        }
+
+        hello q[0], q[1];
+        world(0.1, 0.2) q[2];
+        hello q[2], q[1];
+        """
+        )
+        assert [g.label for g in circ.gates] == [
+            "H",
+            "CX",
+            "U3",
+            "PHASE",
+            "PHASE",
+            "H",
+            "CX",
+            "U3",
+        ]
+
+    def test_openqasm3_from_file(self, tmp_path):
+        qasm_file = tmp_path / "test.qasm"
+        qasm_file.write_text(
+            """
+        OPENQASM 3;
+        include "stdgates.inc";
+        qubit[2] q;
+        h q[0];
+        cx q[0], q[1];
+        """
+        )
+        circ = qtn.Circuit.from_openqasm3_file(qasm_file)
+        assert [g.label for g in circ.gates] == ["H", "CX"]
+
+    def test_openqasm3_custom_gate_name_collisions(self):
+        # a formal parameter or qubit named like a gate must not clobber the
+        # gate labels used in the body of the custom gate definition
+        circ = qtn.Circuit.from_openqasm3_str(
+            """
+        OPENQASM 3;
+        include "stdgates.inc";
+        qubit[2] q;
+        gate g1(h) a {
+            h a;
+            rx(h) a;
+        }
+        gate g2 x, cx {
+            cx x, cx;
+        }
+        g1(0.5) q[0];
+        g2 q[0], q[1];
+        """
+        )
+        assert [g.label for g in circ.gates] == ["H", "RX", "CX"]
+        assert circ.gates[1].params[0] == pytest.approx(0.5)
+        assert circ.gates[2].qubits == (0, 1)
+
+    def test_openqasm3_gphase_ignored(self):
+        with pytest.warns(SyntaxWarning):
+            circ = qtn.Circuit.from_openqasm3_str(
+                """
+            OPENQASM 3;
+            include "stdgates.inc";
+            qubit[1] q;
+            gphase(pi / 2);
+            h q[0];
+            """
+            )
+        assert [g.label for g in circ.gates] == ["H"]
+
+    def test_openqasm3_unsupported_operations(self):
+        with pytest.raises(NotImplementedError):
+            qtn.Circuit.from_openqasm3_str(
+                """
+            OPENQASM 3;
+            input angle theta;
+            qubit q;
+            rz(theta) q;
+            """
+            )
+
+        with pytest.raises(NotImplementedError):
+            qtn.Circuit.from_openqasm3_str(
+                """
+            OPENQASM 3;
+            qubit q;
+            if (true) {
+                x q;
+            }
+            """
+            )
+
+    @pytest.mark.parametrize(
+        "modifier",
+        ["ctrl @", "ctrl(2) @", "negctrl @", "inv @", "pow(2) @"],
+    )
+    def test_openqasm3_gate_modifiers_unsupported(self, modifier):
+        with pytest.raises(NotImplementedError):
+            qtn.Circuit.from_openqasm3_str(
+                f"""
+            OPENQASM 3;
+            include "stdgates.inc";
+            qubit[3] q;
+            {modifier} x q[0], q[1], q[2];
+            """
+            )
 
     @pytest.mark.parametrize(
         "Circ", [qtn.Circuit, qtn.CircuitMPS, qtn.CircuitDense]


### PR DESCRIPTION
## Summary

Adds a small, dependency-free OpenQASM 3 parser to `Circuit`, mirroring the
existing OpenQASM 2 API for #256 

- new helpers `parse_openqasm3_str` / `parse_openqasm3_file` /
  `parse_openqasm3_url`
- new constructors `Circuit.from_openqasm3_str` / `from_openqasm3_file` /
  `from_openqasm3_url`

This follows the maintainer's scope guidance on the issue: basic circuit/gate
functionality comparable to the current OpenQASM 2 parser, with unsupported
operations erroring clearly. It is intentionally **not** a full OpenQASM 3
grammar implementation.

## Supported

- `OPENQASM 3;` / `OPENQASM 3.0;` headers and `include` lines
- `qubit[n] name;` registers and `qubit name;` single qubits
- line (`//`) and block (`/* */`) comments
- `const` numeric parameters and constant-index operands (e.g. `h q[n];`)
- `let` aliases
- custom `gate` definitions, including nested definitions
- stdgate aliases mapped to quimb gates (`p`..`PHASE`, `cp`..`CPHASE`, `U`..`U3`)
- parameter expressions via a restricted evaluator (`pi`, `tau`, `e`, and
  common math functions; no builtins), consistent with the OpenQASM 2 parser

Classical declarations (`bit`, `int`, ...) and `measure` / `barrier` / `reset`
/ `gphase` are accepted and ignored with a one-time `SyntaxWarning`, matching
the OpenQASM 2 behaviour (global phase does not affect measurement outcomes).

## Clearly rejected (informative errors)

- control flow: `if` / `for` / `while` / `switch`
- `def` / `defcal` / `cal` / `box` / timing (`delay`, `stretch`, `duration`)
- gate modifiers: `ctrl @`, `ctrl(2) @`, `negctrl @`, `inv @`, `pow(2) @`, ...
- unbound `input` parameters

## Known limitations

- **Unbound / symbolic `input` parameters are not supported.** The
  Gate/autoray pipeline cannot yet carry symbolic parameters, so rather than
  mishandling them these raise a clear `NotImplementedError`. Concrete and
  `const`-evaluable values are fully supported. Symbolic-input support is a
  natural follow-up.
- Gate broadcasting over a whole register (`h q;` for a multi-qubit `q`) is not
  supported .. index individual qubits (`h q[0];`). Single-qubit registers may
  be referenced by name. This matches the OpenQASM 2 parser's behaviour.

## Implementation notes

- a small lexer (`_split_openqasm_statements`) tokenizes the source into
  `;`/`{`/`}`-delimited statements while correctly skipping comments and string
  literals.
- custom-gate bodies are expanded by substituting formal parameters/qubits
  **only within the parameter and operand regions** of each body line (never
  the gate label), using word-boundary matching. This avoids two classes of
  bug: a formal name colliding with a gate label (e.g. a parameter called `h`),
  and one formal name being matched inside another (e.g. `x` inside `cx`).

## Tests

`tests/test_tensor/test_circuit.py` adds coverage for: QFT parsing and
statevector-equivalence with the OpenQASM 2 path, stdgate aliases + constants,
`let` aliases, custom gates (incl. name/label collisions), file parsing,
ignored `gphase`, and rejection of `input` parameters, control flow and gate
modifiers.

- `pytest -q tests/test_tensor/test_circuit.py -k "openqasm or from_openqasm"`
- `pytest -q tests/test_tensor/test_circuit.py::TestCircuit`
- `python -m ruff check quimb/tensor/circuit.py tests/test_tensor/test_circuit.py`