### PR TITLE
Add CircuitPEPSSimpleUpdate, a PEPS quantum circuit simulator (closes #358)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ Release notes for `quimb`.
 
 **Enhancements:**
 
+- add [`CircuitPEPSSimpleUpdate`](quimb.tensor.circuit.CircuitPEPSSimpleUpdate): a high level quantum circuit simulator that keeps the state as an arbitrary geometry PEPS and applies nearest-neighbor gates with 'simple update' style gauging. The geometry is given by a set of ``edges``, inferred from the ``gates``, or read from a ``psi0``; the accuracy is set by ``max_bond``; gauges can be periodically re-equilibrated with ``equilibrate``; and local expectations are computed with the cluster approximation.
 - [`TensorNetwork.gauge_all_simple`](quimb.tensor.tensor_core.TensorNetwork.gauge_all_simple): add a ``fuse_multibonds`` option for updating gauges while preserving multi-index bonds, supported by explicit bond-index selection in [`tensor_compress_bond`](quimb.tensor.tensor_core.tensor_compress_bond).
 - add [`LatticeBondMap`](quimb.tensor.tnag.core.LatticeBondMap): helper for consistently assigning lattice bond indices across ordinary and periodic boundaries, use it in PEPS, PEPO, PEPS3D, scalar 2D/3D lattice tensor-network construction, and classical Ising tensor-network construction.
 - [`eigh_truncated`](quimb.tensor.decomp.eigh_truncated): add a ``shift`` option for optional diagonal regularization.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@ Release notes for `quimb`.
 
 **Enhancements:**
 
-- add [`CircuitPEPSSimpleUpdate`](quimb.tensor.circuit.CircuitPEPSSimpleUpdate): a high level quantum circuit simulator that keeps the state as an arbitrary geometry PEPS and applies nearest-neighbor gates with 'simple update' style gauging. The geometry is given by a set of ``edges``, inferred from the ``gates``, or read from a ``psi0``; the accuracy is set by ``max_bond``; gauges can be periodically re-equilibrated with ``equilibrate``; and local expectations are computed with the cluster approximation.
+- add [`CircuitPEPSSimpleUpdate`](quimb.tensor.circuit.CircuitPEPSSimpleUpdate): a high level quantum circuit simulator that keeps the state as an arbitrary geometry PEPS and applies nearest-neighbor gates with 'simple update' style gauging. The geometry is given by a set of ``edges``, inferred from the ``gates`` or read from a ``psi0``; the accuracy is set by ``max_bond``; gauges can be periodically re-equilibrated with ``equilibrate``; local expectations are computed with the cluster approximation.
 - [`TensorNetwork.gauge_all_simple`](quimb.tensor.tensor_core.TensorNetwork.gauge_all_simple): add a ``fuse_multibonds`` option for updating gauges while preserving multi-index bonds, supported by explicit bond-index selection in [`tensor_compress_bond`](quimb.tensor.tensor_core.tensor_compress_bond).
 - add [`LatticeBondMap`](quimb.tensor.tnag.core.LatticeBondMap): helper for consistently assigning lattice bond indices across ordinary and periodic boundaries, use it in PEPS, PEPO, PEPS3D, scalar 2D/3D lattice tensor-network construction, and classical Ising tensor-network construction.
 - [`eigh_truncated`](quimb.tensor.decomp.eigh_truncated): add a ``shift`` option for optional diagonal regularization.

--- a/quimb/tensor/__init__.py
+++ b/quimb/tensor/__init__.py
@@ -4,6 +4,7 @@ from .circuit import (
     Circuit,
     CircuitDense,
     CircuitMPS,
+    CircuitPEPSSimpleUpdate,
     CircuitPermMPS,
     Gate,
 )
@@ -241,6 +242,7 @@ __all__ = (
     "Circuit",
     "CircuitDense",
     "CircuitMPS",
+    "CircuitPEPSSimpleUpdate",
     "CircuitPermMPS",
     "cnf_file_parse",
     "connect",

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -5140,16 +5140,20 @@ class CircuitPEPSSimpleUpdate(Circuit):
         Supply the initial state directly instead of starting from the
         ``|00...0>`` product state. If ``edges`` is not given the geometry is
         read from the bonds of this state, and the bond gauges are seeded from
-        it.
+        it. Only a single seeding sweep is performed; unlike imaginary time
+        simple update the gauge matters immediately, so for an arbitrary
+        ``psi0`` you may want to call :meth:`equilibrate` once before applying
+        gates.
     max_bond : int, optional
         The maximum bond dimension to truncate to when applying gates.
     cutoff : float, optional
         The singular value cutoff to use when truncating after applying gates.
     renorm : bool, optional
         Whether to renormalize the singular values of a bond after each gate.
-        The default ``True`` keeps the state normalized, which is stable for
-        deep circuits of generic gates. Set ``False`` to instead track the norm
-        of the state, e.g. for the near-identity gates of (imaginary) time
+        The default ``False`` tracks the norm of the state rather than forcing
+        it to one, which is the sensible choice for real time and general
+        circuit dynamics. Set ``True`` to instead keep the state normalized
+        after every gate, e.g. for the near-identity gates of imaginary time
         evolution.
     gauge_smudge : float, optional
         Small value added to the gauges before they are multiplied in and
@@ -5162,6 +5166,17 @@ class CircuitPEPSSimpleUpdate(Circuit):
     gate_opts : dict, optional
         Default options to pass to ``gate_simple_`` such as ``max_bond`` and
         ``cutoff``.
+    dtype : str, optional
+        If given, ensure the state tensors are cast to this data type.
+    to_backend : callable, optional
+        If given, apply this function to the state tensors to convert them to a
+        particular array backend.
+    convert_eager : bool, optional
+        Whether to apply the ``dtype`` and ``to_backend`` conversions eagerly
+        as each gate is applied. The default ``True`` matches the other running
+        simulators (e.g. :class:`CircuitMPS`), since the simple update rule
+        contracts each gate into the state immediately rather than building a
+        lazy network to contract later.
 
     Attributes
     ----------
@@ -5201,14 +5216,14 @@ class CircuitPEPSSimpleUpdate(Circuit):
         psi0=None,
         max_bond=None,
         cutoff=1e-10,
-        renorm=True,
+        renorm=False,
         gauge_smudge=1e-12,
         equilibrate_every=None,
         equilibrate_opts=None,
         gate_opts=None,
         dtype=None,
         to_backend=None,
-        convert_eager=False,
+        convert_eager=True,
         **circuit_opts,
     ):
         # geometry can come from explicit `edges`, be inferred from the two
@@ -5227,12 +5242,12 @@ class CircuitPEPSSimpleUpdate(Circuit):
                     "You must supply one of `edges`, `gates` or `psi0` to "
                     "define the PEPS geometry."
                 )
-        self.edges = tuple(gen_unique_edges(edges))
+        self._edges = tuple(gen_unique_edges(edges))
 
         # sites are everything appearing in the edges, plus any extra sites
         # touched by single qubit gates or present in psi0, padded up to N
         sites = set()
-        for a, b in self.edges:
+        for a, b in self._edges:
             sites.add(a)
             sites.add(b)
         sites.update(extra_sites)
@@ -5242,7 +5257,7 @@ class CircuitPEPSSimpleUpdate(Circuit):
             sites.update(range(N))
         self._sites = tuple(sorted(sites))
         self._site_set = set(self._sites)
-        self._edge_set = {frozenset(e) for e in self.edges}
+        self._edge_set = {frozenset(e) for e in self._edges}
 
         # bond gauges tracked across gate applications
         self.gauges = {}
@@ -5278,7 +5293,7 @@ class CircuitPEPSSimpleUpdate(Circuit):
         two circuits can be evolved independently).
         """
         new = super().copy()
-        new.edges = self.edges
+        new._edges = self._edges
         new._sites = self._sites
         new._site_set = self._site_set
         new._edge_set = self._edge_set
@@ -5286,6 +5301,11 @@ class CircuitPEPSSimpleUpdate(Circuit):
         new._equilibrate_every = self._equilibrate_every
         new._equilibrate_opts = dict(self._equilibrate_opts)
         return new
+
+    @property
+    def edges(self):
+        """The unique edges defining the PEPS geometry."""
+        return self._edges
 
     @property
     def sites(self):
@@ -5346,7 +5366,7 @@ class CircuitPEPSSimpleUpdate(Circuit):
         if self._equilibrate_every and (
             len(self._gates) % self._equilibrate_every == 0
         ):
-            self.equilibrate(**self._equilibrate_opts)
+            self.equilibrate()
 
     def apply_gates(self, gates, progbar=False, **gate_opts):
         if progbar:
@@ -5363,35 +5383,33 @@ class CircuitPEPSSimpleUpdate(Circuit):
             if progbar and (gate.total_qubit_count >= 2):
                 gates.set_description(f"max_bond={self._psi.max_bond()}")
 
-    def equilibrate(self, max_iterations=100, tol=1e-10, **gauge_opts):
+    def equilibrate(self, **gauge_opts):
         """Re-gauge the whole state with the simple update rule, improving the
         consistency of the tracked bond gauges. This does not change the state
         represented, only the gauge, and can be called periodically between
         rounds of gates to keep the simple update approximation well behaved.
 
+        The default options given at construction via ``equilibrate_opts`` are
+        applied first, with any keyword arguments here taking precedence.
+
         Parameters
         ----------
-        max_iterations : int, optional
-            The maximum number of gauging sweeps.
-        tol : float, optional
-            The convergence tolerance on the change in singular values.
         gauge_opts
             Supplied to
-            :meth:`~quimb.tensor.tensor_core.TensorNetwork.gauge_all_simple_`.
+            :meth:`~quimb.tensor.tensor_core.TensorNetwork.gauge_all_simple_`,
+            for example ``max_iterations`` and ``tol``.
         """
-        self._psi.gauge_all_simple_(
-            max_iterations=max_iterations,
-            tol=tol,
-            gauges=self.gauges,
-            **gauge_opts,
-        )
+        opts = {**self._equilibrate_opts, **gauge_opts}
+        opts.setdefault("max_iterations", 100)
+        opts.setdefault("tol", 1e-10)
+        self._psi.gauge_all_simple_(gauges=self.gauges, **opts)
 
     def local_expectation(
         self,
         G,
         where,
         *,
-        max_distance=1,
+        max_distance=0,
         normalized=True,
         **contract_opts,
     ):
@@ -5409,7 +5427,9 @@ class CircuitPEPSSimpleUpdate(Circuit):
             detected by membership in the set of sites.
         max_distance : int, optional
             How many graph hops of neighboring tensors to include in the local
-            cluster used to approximate the reduced density matrix.
+            cluster used to approximate the reduced density matrix. The default
+            ``0`` uses only the target site(s) and their gauges, matching
+            :meth:`~quimb.tensor.tnag.core.TensorNetworkGenVector.compute_local_expectation_cluster`.
         normalized : bool, optional
             Whether to normalize by the local norm.
         contract_opts
@@ -5434,31 +5454,56 @@ class CircuitPEPSSimpleUpdate(Circuit):
             **contract_opts,
         )
 
-    @property
-    def psi(self):
-        """The PEPS tensor network state, with the simple update bond gauges
-        absorbed back in so that it represents the actual wavefunction (a
-        proper contraction of ``psi`` gives the state, up to the simple update
-        approximation). The internal gauged form is left untouched.
+    def get_state(self, absorb_gauges=True):
+        """Return the current PEPS state, optionally absorbing the bond gauges.
+
+        Parameters
+        ----------
+        absorb_gauges : bool or "return", optional
+            How to handle the tracked Vidal-style bond gauges. If ``True`` (the
+            default) the gauges are absorbed, so the returned tensor network is
+            the actual wavefunction (up to the simple update approximation). If
+            ``False`` the gauges are added to the network as uncontracted
+            diagonal tensors. If ``"return"`` the raw gauged network and a copy
+            of the gauges are returned separately. The internal state is left
+            untouched in every case.
+
+        Returns
+        -------
+        psi : TensorNetwork
+            The current state.
+        gauges : dict
+            The current gauges, only if ``absorb_gauges == "return"``.
         """
         psi = self._psi.copy()
-        # absorb the Vidal-form bond gauges so the returned TN is the state
-        psi.gauge_simple_insert(self.gauges)
+
+        if absorb_gauges == "return":
+            gauges = dict(self.gauges)
+            if not self.convert_eager:
+                self._maybe_convert(psi)
+            return psi, gauges
+
+        if absorb_gauges:
+            # absorb the Vidal-form bond gauges so the returned TN is the state
+            psi.gauge_simple_insert(self.gauges)
+        else:
+            # add the gauges as uncontracted diagonal tensors on their bonds
+            for ix, g in self.gauges.items():
+                psi |= Tensor(g, inds=[ix])
+
         if not self.convert_eager:
             self._maybe_convert(psi)
         return psi
 
     @property
-    def psi_gauged(self):
-        """The raw internal tensor network, in Vidal (simple update) gauge.
-        The bond singular values are stored separately in ``self.gauges`` and
-        are *not* absorbed, so this is not directly the wavefunction. Use
-        :attr:`psi` for that.
+    def psi(self):
+        """The PEPS tensor network state, with the simple update bond gauges
+        absorbed back in so that it represents the actual wavefunction (a
+        proper contraction of ``psi`` gives the state, up to the simple update
+        approximation). The internal gauged form is left untouched. Shorthand
+        for ``get_state(absorb_gauges=True)``.
         """
-        psi = self._psi.copy()
-        if not self.convert_eager:
-            self._maybe_convert(psi)
-        return psi
+        return self.get_state(absorb_gauges=True)
 
     def calc_qubit_ordering(self, qubits=None):
         if qubits is None:
@@ -5475,7 +5520,15 @@ class CircuitPEPSSimpleUpdate(Circuit):
         )
 
     def to_dense(self, *args, **kwargs):
-        self._unsupported_exact("to_dense")
+        """Contract the gauged PEPS into a dense wavefunction, a column-vector
+        ``qarray`` of length ``2**N`` ordered like :attr:`sites`, matching the
+        output of :meth:`Circuit.to_dense`. This is the actual (approximate)
+        state, so the cost grows exponentially with the number of qubits.
+
+        Arguments are forwarded to
+        :meth:`~quimb.tensor.tnag.core.TensorNetworkGenVector.to_dense`.
+        """
+        return self.psi.to_dense(*args, **kwargs)
 
     def amplitude(self, *args, **kwargs):
         self._unsupported_exact("amplitude")

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -30,6 +30,7 @@ from .tensor_builder import (
     MPO_identity_like,
     MPS_computational_state,
     TN_from_sites_computational_state,
+    TN_from_sites_product_state,
 )
 from .tensor_core import (
     PTensor,
@@ -5104,3 +5105,278 @@ class CircuitDense(Circuit):
         the lightcone is not meaningful.
         """
         return self.psi
+
+
+class CircuitPEPSSimpleUpdate(Circuit):
+    """Quantum circuit simulation keeping the state as a generic tensor
+    network (a "PEPS" defined by an arbitrary graph of ``edges``) and applying
+    gates with the simple update rule. The state always keeps a single tensor
+    per site, with bonds only along the supplied edges; two-qubit gates are
+    only supported on those edges. Bond singular values are tracked as
+    Vidal-style gauges, which makes gate application and the computation of
+    local expectations cheap and approximate.
+
+    This is useful for circuits on lattices that build up more than 1D worth of
+    entanglement, where an exact or MPS simulation is intractable but a
+    truncated, gauged tensor network state is a good approximation.
+
+    Parameters
+    ----------
+    N : int, optional
+        The number of qubits in the circuit. If not given it is inferred from
+        ``edges``.
+    edges : sequence[tuple[int, int]]
+        The edges defining the geometry of the PEPS. A bond is placed between
+        each pair of sites, and two-qubit gates are only supported on these
+        edges. Every site appearing in ``edges`` is included. Supply ``N`` as
+        well to pad the geometry up to that many sites, including any that have
+        no edges.
+    max_bond : int, optional
+        The maximum bond dimension to truncate to when applying gates.
+    cutoff : float, optional
+        The singular value cutoff to use when truncating after applying gates.
+    gate_opts : dict, optional
+        Default options to pass to ``gate_simple_`` such as ``max_bond`` and
+        ``cutoff``.
+
+    Attributes
+    ----------
+    gauges : dict[str, array]
+        The current Vidal-style bond gauges (singular values), keyed by bond
+        index, updated in place as gates are applied.
+
+    Notes
+    -----
+    The gates applied must address qubits using the same labels that appear in
+    ``edges``. Two-qubit gates are only supported along an existing edge.
+
+    Examples
+    --------
+
+        >>> import quimb.tensor as qtn
+        >>> edges = [(0, 1), (1, 2), (0, 3), (1, 4), (2, 5), (3, 4), (4, 5)]
+        >>> circ = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=8)
+        >>> circ.apply_gates(gates)
+        >>> peps = circ.psi
+
+    See Also
+    --------
+    CircuitMPS, CircuitDense
+    """
+
+    def __init__(
+        self,
+        N=None,
+        *,
+        edges=None,
+        psi0=None,
+        max_bond=None,
+        cutoff=1e-10,
+        gate_opts=None,
+        dtype=None,
+        to_backend=None,
+        convert_eager=False,
+        **circuit_opts,
+    ):
+        if edges is None:
+            raise ValueError(
+                "You must supply `edges` defining the PEPS geometry."
+            )
+        self.edges = tuple((a, b) for a, b in edges)
+
+        # sites are everything appearing in edges, padded up to N if given
+        sites = set()
+        for a, b in self.edges:
+            sites.add(a)
+            sites.add(b)
+        if N is not None:
+            sites.update(range(N))
+        self._sites = tuple(sorted(sites))
+
+        # bond gauges tracked across gate applications
+        self.gauges = {}
+
+        gate_opts = ensure_dict(gate_opts)
+        gate_opts.setdefault("max_bond", max_bond)
+        gate_opts.setdefault("cutoff", cutoff)
+
+        circuit_opts.setdefault("tag_gate_numbers", False)
+        circuit_opts.setdefault("tag_gate_rounds", False)
+        circuit_opts.setdefault("tag_gate_labels", False)
+
+        circuit_opts.setdefault("dtype", dtype)
+        circuit_opts.setdefault("to_backend", to_backend)
+        circuit_opts.setdefault("convert_eager", convert_eager)
+
+        super().__init__(len(self._sites), psi0, gate_opts, **circuit_opts)
+
+    def _init_state(self, N, dtype="complex128"):
+        # |00...0> product state with bond dimension 1 bonds along the edges
+        zero = do("array", [1.0, 0.0], dtype=dtype)
+        psi = TN_from_sites_product_state({site: zero for site in self._sites})
+        for a, b in self.edges:
+            psi[a].new_bond(psi[b])
+        return psi
+
+    def _apply_gate(self, gate, tags=None, **gate_opts):
+        # route gate application through the simple update rule, threading the
+        # persistent bond gauges so they stay consistent between gates
+        if gate.controls:
+            raise ValueError(
+                "Controlled gates are not supported by "
+                "`CircuitPEPSSimpleUpdate`, since the simple update rule "
+                "applies a dense gate array to the sites. Supply the gate as "
+                "a full unitary on its qubits instead."
+            )
+        if gate.special:
+            raise ValueError(
+                f"The special gate {gate.label!r} is not supported by "
+                "`CircuitPEPSSimpleUpdate`. Supply a gate with an explicit "
+                "array acting on sites connected by an edge."
+            )
+
+        opts = {**self.gate_opts, **gate_opts}
+        opts.pop("contract", None)
+        opts.pop("propagate_tags", None)
+
+        G = gate.array
+        if self.convert_eager:
+            key = id(G)
+            if key not in self._backend_gate_cache:
+                self._backend_gate_cache[key] = self._maybe_convert(G)
+            G = self._backend_gate_cache[key]
+
+        self._psi.gate_simple_(G, gate.qubits, self.gauges, **opts)
+        self._gates.append(gate)
+
+    def apply_gates(self, gates, progbar=False, **gate_opts):
+        if progbar:
+            from ..utils import progbar as _progbar
+
+            gates = tuple(gates)
+            gates = _progbar(gates, total=len(gates))
+            gates.set_description(f"max_bond={self._psi.max_bond()}")
+
+        for gate in gates:
+            gate = parse_to_gate(gate)
+            self._apply_gate(gate, **gate_opts)
+
+            if progbar and (gate.total_qubit_count >= 2):
+                gates.set_description(f"max_bond={self._psi.max_bond()}")
+
+    def equilibrate(self, max_iterations=100, tol=1e-10, **gauge_opts):
+        """Re-gauge the whole state with the simple update rule, improving the
+        consistency of the tracked bond gauges. This does not change the state
+        represented, only the gauge, and can be called periodically between
+        rounds of gates to keep the simple update approximation well behaved.
+
+        Parameters
+        ----------
+        max_iterations : int, optional
+            The maximum number of gauging sweeps.
+        tol : float, optional
+            The convergence tolerance on the change in singular values.
+        gauge_opts
+            Supplied to
+            :meth:`~quimb.tensor.tensor_core.TensorNetwork.gauge_all_simple_`.
+        """
+        self._psi.gauge_all_simple_(
+            max_iterations=max_iterations,
+            tol=tol,
+            gauges=self.gauges,
+            **gauge_opts,
+        )
+
+    def local_expectation(
+        self,
+        G,
+        where,
+        *,
+        max_distance=1,
+        normalized=True,
+        **contract_opts,
+    ):
+        """Compute the local expectation value of operator ``G`` at the site(s)
+        ``where``, using the simple update bond gauges to approximate the
+        environment beyond ``max_distance``.
+
+        Parameters
+        ----------
+        G : array_like
+            The local operator.
+        where : int or tuple[int]
+            The site or sites to compute the expectation at.
+        max_distance : int, optional
+            How many graph hops of neighboring tensors to include in the local
+            cluster used to approximate the reduced density matrix.
+        normalized : bool, optional
+            Whether to normalize by the local norm.
+        contract_opts
+            Supplied to
+            :meth:`~quimb.tensor.tnag.core.TensorNetworkGenVector.compute_local_expectation_cluster`.
+
+        Returns
+        -------
+        float
+        """
+        if isinstance(where, int):
+            where = (where,)
+        return self._psi.compute_local_expectation_cluster(
+            {tuple(where): G},
+            gauges=self.gauges,
+            max_distance=max_distance,
+            normalized=normalized,
+            **contract_opts,
+        )
+
+    @property
+    def psi(self):
+        """The PEPS tensor network state, with the simple update bond gauges
+        absorbed back in so that it represents the actual wavefunction (a
+        proper contraction of ``psi`` gives the state, up to the simple update
+        approximation). The internal gauged form is left untouched.
+        """
+        psi = self._psi.copy()
+        # absorb the Vidal-form bond gauges so the returned TN is the state
+        psi.gauge_simple_insert(self.gauges)
+        if not self.convert_eager:
+            self._maybe_convert(psi)
+        return psi
+
+    @property
+    def psi_gauged(self):
+        """The raw internal tensor network, in Vidal (simple update) gauge.
+        The bond singular values are stored separately in ``self.gauges`` and
+        are *not* absorbed, so this is not directly the wavefunction. Use
+        :attr:`psi` for that.
+        """
+        psi = self._psi.copy()
+        if not self.convert_eager:
+            self._maybe_convert(psi)
+        return psi
+
+    def calc_qubit_ordering(self, qubits=None):
+        if qubits is None:
+            return tuple(self._sites)
+        return tuple(sorted(qubits))
+
+    def _unsupported_exact(self, name):
+        raise NotImplementedError(
+            f"`{name}` is not supported by `CircuitPEPSSimpleUpdate`, which "
+            "only ever holds an approximate, gauged tensor network state. Use "
+            "`local_expectation` for observables, or `psi` to get the gauged "
+            "PEPS state and contract or sample it with the approximation you "
+            "want."
+        )
+
+    def to_dense(self, *args, **kwargs):
+        self._unsupported_exact("to_dense")
+
+    def amplitude(self, *args, **kwargs):
+        self._unsupported_exact("amplitude")
+
+    def sample(self, *args, **kwargs):
+        self._unsupported_exact("sample")
+
+    def sample_chaotic(self, *args, **kwargs):
+        self._unsupported_exact("sample_chaotic")

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -5145,12 +5145,30 @@ class CircuitPEPSSimpleUpdate(Circuit):
         The maximum bond dimension to truncate to when applying gates.
     cutoff : float, optional
         The singular value cutoff to use when truncating after applying gates.
+    renorm : bool, optional
+        Whether to renormalize the singular values of a bond after each gate.
+        The default ``True`` keeps the state normalized, which is stable for
+        deep circuits of generic gates. Set ``False`` to instead track the norm
+        of the state, e.g. for the near-identity gates of (imaginary) time
+        evolution.
+    gauge_smudge : float, optional
+        Small value added to the gauges before they are multiplied in and
+        inverted, for numerical stability with very small singular values.
+    equilibrate_every : int, optional
+        If given, automatically call :meth:`equilibrate` after every this many
+        gates have been applied.
+    equilibrate_opts : dict, optional
+        Default options forwarded to :meth:`equilibrate`.
     gate_opts : dict, optional
         Default options to pass to ``gate_simple_`` such as ``max_bond`` and
         ``cutoff``.
 
     Attributes
     ----------
+    edges : tuple[tuple[hashable, hashable]]
+        The unique edges defining the PEPS geometry.
+    sites : tuple[hashable]
+        The sites (qubit labels) of the PEPS.
     gauges : dict[str, array]
         The current Vidal-style bond gauges (singular values), keyed by bond
         index, updated in place as gates are applied.
@@ -5183,6 +5201,10 @@ class CircuitPEPSSimpleUpdate(Circuit):
         psi0=None,
         max_bond=None,
         cutoff=1e-10,
+        renorm=True,
+        gauge_smudge=1e-12,
+        equilibrate_every=None,
+        equilibrate_opts=None,
         gate_opts=None,
         dtype=None,
         to_backend=None,
@@ -5219,13 +5241,21 @@ class CircuitPEPSSimpleUpdate(Circuit):
         if N is not None:
             sites.update(range(N))
         self._sites = tuple(sorted(sites))
+        self._site_set = set(self._sites)
+        self._edge_set = {frozenset(e) for e in self.edges}
 
         # bond gauges tracked across gate applications
         self.gauges = {}
 
+        # auto re-gauge every this many gates, if given
+        self._equilibrate_every = equilibrate_every
+        self._equilibrate_opts = ensure_dict(equilibrate_opts)
+
         gate_opts = ensure_dict(gate_opts)
         gate_opts.setdefault("max_bond", max_bond)
         gate_opts.setdefault("cutoff", cutoff)
+        gate_opts.setdefault("renorm", renorm)
+        gate_opts.setdefault("smudge", gauge_smudge)
 
         circuit_opts.setdefault("tag_gate_numbers", False)
         circuit_opts.setdefault("tag_gate_rounds", False)
@@ -5240,6 +5270,27 @@ class CircuitPEPSSimpleUpdate(Circuit):
         if psi0 is not None:
             # seed the bond gauges from the supplied state
             self._psi.gauge_all_simple_(gauges=self.gauges, max_iterations=1)
+
+    def copy(self):
+        """Copy the circuit, including its state, gauges and geometry. The
+        base :class:`Circuit` copy does not know about the extra simple update
+        attributes, so they are carried over here (the gauges are copied so the
+        two circuits can be evolved independently).
+        """
+        new = super().copy()
+        new.edges = self.edges
+        new._sites = self._sites
+        new._site_set = self._site_set
+        new._edge_set = self._edge_set
+        new.gauges = dict(self.gauges)
+        new._equilibrate_every = self._equilibrate_every
+        new._equilibrate_opts = dict(self._equilibrate_opts)
+        return new
+
+    @property
+    def sites(self):
+        """The sites (qubit labels) of the PEPS."""
+        return self._sites
 
     def _init_state(self, N, dtype="complex128"):
         # |00...0> product state with bond dimension 1 bonds along the edges
@@ -5266,6 +5317,18 @@ class CircuitPEPSSimpleUpdate(Circuit):
                 "array acting on sites connected by an edge."
             )
 
+        where = gate.qubits
+        if len(where) > 2:
+            raise ValueError(
+                "`CircuitPEPSSimpleUpdate` only supports one and two site "
+                f"gates, but got {len(where)} sites: {where}."
+            )
+        if (len(where) == 2) and (frozenset(where) not in self._edge_set):
+            raise ValueError(
+                f"The gate acts on sites {where} which are not a declared "
+                "edge of the PEPS, only nearest neighbor gates are allowed."
+            )
+
         opts = {**self.gate_opts, **gate_opts}
         opts.pop("contract", None)
         opts.pop("propagate_tags", None)
@@ -5277,8 +5340,13 @@ class CircuitPEPSSimpleUpdate(Circuit):
                 self._backend_gate_cache[key] = self._maybe_convert(G)
             G = self._backend_gate_cache[key]
 
-        self._psi.gate_simple_(G, gate.qubits, self.gauges, **opts)
+        self._psi.gate_simple_(G, where, self.gauges, **opts)
         self._gates.append(gate)
+
+        if self._equilibrate_every and (
+            len(self._gates) % self._equilibrate_every == 0
+        ):
+            self.equilibrate(**self._equilibrate_opts)
 
     def apply_gates(self, gates, progbar=False, **gate_opts):
         if progbar:
@@ -5335,8 +5403,10 @@ class CircuitPEPSSimpleUpdate(Circuit):
         ----------
         G : array_like
             The local operator.
-        where : int or tuple[int]
-            The site or sites to compute the expectation at.
+        where : hashable or sequence[hashable]
+            The site or sites to compute the expectation at. A single site
+            label (which may itself be a tuple, e.g. a 2D coordinate) is
+            detected by membership in the set of sites.
         max_distance : int, optional
             How many graph hops of neighboring tensors to include in the local
             cluster used to approximate the reduced density matrix.
@@ -5350,10 +5420,12 @@ class CircuitPEPSSimpleUpdate(Circuit):
         -------
         float
         """
-        if isinstance(where, int):
+        if where in self._site_set:
             where = (where,)
+        else:
+            where = tuple(where)
         return self._psi.compute_local_expectation_cluster(
-            {tuple(where): G},
+            {where: G},
             gauges=self.gauges,
             max_distance=max_distance,
             normalized=normalized,
@@ -5411,3 +5483,22 @@ class CircuitPEPSSimpleUpdate(Circuit):
 
     def sample_chaotic(self, *args, **kwargs):
         self._unsupported_exact("sample_chaotic")
+
+    def sample_chaotic_rehearse(self, *args, **kwargs):
+        self._unsupported_exact("sample_chaotic_rehearse")
+
+    def partial_trace(self, *args, **kwargs):
+        self._unsupported_exact("partial_trace")
+
+    @property
+    def uni(self):
+        raise NotImplementedError(
+            "`uni` (the dense circuit unitary) is not available for "
+            "`CircuitPEPSSimpleUpdate`, which never forms the full unitary. "
+            "Apply gates to a state and use `psi` or `local_expectation`."
+        )
+
+    def get_psi_reverse_lightcone(self, where, keep_psi0=False):
+        # the reverse lightcone is not meaningful for a simple update PEPS,
+        # which always keeps the whole state, so just return it
+        return self.psi

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -5212,7 +5212,7 @@ class CircuitPEPSSimpleUpdate(Circuit):
         **circuit_opts,
     ):
         # geometry can come from explicit `edges`, be inferred from the two
-        # site `gates` (only inspected here, not applied), or be read from the
+        # site `gates` (only inspected here, not applied) or be read from the
         # bonds of an existing `psi0`
         extra_sites = ()
         if edges is None:
@@ -5420,6 +5420,8 @@ class CircuitPEPSSimpleUpdate(Circuit):
         -------
         float
         """
+        if isinstance(where, list):
+            where = tuple(where)
         if where in self._site_set:
             where = (where,)
         else:
@@ -5467,7 +5469,7 @@ class CircuitPEPSSimpleUpdate(Circuit):
         raise NotImplementedError(
             f"`{name}` is not supported by `CircuitPEPSSimpleUpdate`, which "
             "only ever holds an approximate, gauged tensor network state. Use "
-            "`local_expectation` for observables, or `psi` to get the gauged "
+            "`local_expectation` for observables or `psi` to get the gauged "
             "PEPS state and contract or sample it with the approximation you "
             "want."
         )

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -31,6 +31,7 @@ from .tensor_builder import (
     MPS_computational_state,
     TN_from_sites_computational_state,
     TN_from_sites_product_state,
+    gen_unique_edges,
 )
 from .tensor_core import (
     PTensor,
@@ -5124,13 +5125,22 @@ class CircuitPEPSSimpleUpdate(Circuit):
     ----------
     N : int, optional
         The number of qubits in the circuit. If not given it is inferred from
-        ``edges``.
-    edges : sequence[tuple[int, int]]
+        the geometry. Supply it to pad the geometry up to ``N`` sites,
+        including any that have no edges.
+    edges : sequence[tuple[int, int]], optional
         The edges defining the geometry of the PEPS. A bond is placed between
         each pair of sites, and two-qubit gates are only supported on these
-        edges. Every site appearing in ``edges`` is included. Supply ``N`` as
-        well to pad the geometry up to that many sites, including any that have
-        no edges.
+        edges. Every site appearing in ``edges`` is included. If not given the
+        geometry is taken from ``gates`` or ``psi0`` instead.
+    gates : sequence, optional
+        If ``edges`` is not given, infer the geometry from the two-qubit gates
+        in this sequence. The gates are only inspected here, not applied, so
+        you still pass them to :meth:`apply_gates` afterwards.
+    psi0 : TensorNetworkGenVector, optional
+        Supply the initial state directly instead of starting from the
+        ``|00...0>`` product state. If ``edges`` is not given the geometry is
+        read from the bonds of this state, and the bond gauges are seeded from
+        it.
     max_bond : int, optional
         The maximum bond dimension to truncate to when applying gates.
     cutoff : float, optional
@@ -5169,6 +5179,7 @@ class CircuitPEPSSimpleUpdate(Circuit):
         N=None,
         *,
         edges=None,
+        gates=None,
         psi0=None,
         max_bond=None,
         cutoff=1e-10,
@@ -5178,17 +5189,33 @@ class CircuitPEPSSimpleUpdate(Circuit):
         convert_eager=False,
         **circuit_opts,
     ):
+        # geometry can come from explicit `edges`, be inferred from the two
+        # site `gates` (only inspected here, not applied), or be read from the
+        # bonds of an existing `psi0`
+        extra_sites = ()
         if edges is None:
-            raise ValueError(
-                "You must supply `edges` defining the PEPS geometry."
-            )
-        self.edges = tuple((a, b) for a, b in edges)
+            if psi0 is not None:
+                edges = tuple(psi0.gen_bond_coos())
+            elif gates is not None:
+                parsed = [parse_to_gate(g) for g in gates]
+                edges = [g.qubits for g in parsed if len(g.qubits) == 2]
+                extra_sites = tuple(q for g in parsed for q in g.qubits)
+            else:
+                raise ValueError(
+                    "You must supply one of `edges`, `gates` or `psi0` to "
+                    "define the PEPS geometry."
+                )
+        self.edges = tuple(gen_unique_edges(edges))
 
-        # sites are everything appearing in edges, padded up to N if given
+        # sites are everything appearing in the edges, plus any extra sites
+        # touched by single qubit gates or present in psi0, padded up to N
         sites = set()
         for a, b in self.edges:
             sites.add(a)
             sites.add(b)
+        sites.update(extra_sites)
+        if psi0 is not None:
+            sites.update(psi0.sites)
         if N is not None:
             sites.update(range(N))
         self._sites = tuple(sorted(sites))
@@ -5209,6 +5236,10 @@ class CircuitPEPSSimpleUpdate(Circuit):
         circuit_opts.setdefault("convert_eager", convert_eager)
 
         super().__init__(len(self._sites), psi0, gate_opts, **circuit_opts)
+
+        if psi0 is not None:
+            # seed the bond gauges from the supplied state
+            self._psi.gauge_all_simple_(gauges=self.gauges, max_iterations=1)
 
     def _init_state(self, N, dtype="complex128"):
         # |00...0> product state with bond dimension 1 bonds along the edges

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -1066,8 +1066,6 @@ class TestCircuitPEPSSimpleUpdate:
         # exact-state methods are not meaningful for a gauged approximate state
         circ.apply_gates([qtn.Gate("H", params=(), qubits=[0])])
         with pytest.raises(NotImplementedError):
-            circ.to_dense()
-        with pytest.raises(NotImplementedError):
             circ.amplitude("000")
         with pytest.raises(NotImplementedError):
             list(circ.sample(2))
@@ -1080,6 +1078,62 @@ class TestCircuitPEPSSimpleUpdate:
         # a two-qubit gate off any declared edge is rejected
         with pytest.raises(ValueError):
             circ.apply_gates([qtn.Gate("CZ", params=(), qubits=[0, 2])])
+
+    def test_to_dense_matches_exact_on_a_chain(self):
+        # on a chain at large bond simple update is exact, so the gauged dense
+        # contraction should match a dense Circuit up to a global phase
+        N = 5
+        edges = qtn.edges_1d_chain(N, cyclic=False)
+        rng = np.random.default_rng(2)
+        gates = [
+            (qu.rand_uni(2, seed=int(rng.integers(1 << 30))), i)
+            for i in range(N)
+        ]
+        gates += [
+            (qu.rand_uni(4, seed=int(rng.integers(1 << 30))), a, b)
+            for a, b in edges
+        ]
+        circ = qtn.CircuitPEPSSimpleUpdate(
+            edges=edges, max_bond=32, cutoff=1e-12
+        )
+        circ.apply_gates(gates)
+
+        exact = qtn.Circuit(N=N)
+        exact.apply_gates(gates)
+
+        k_su = circ.to_dense()
+        k_ex = exact.to_dense()
+        # column vector of the full state, matching Circuit.to_dense
+        assert k_su.shape == k_ex.shape == (2**N, 1)
+        assert qu.fidelity(k_su, k_ex) == pytest.approx(1.0, abs=1e-8)
+
+    def test_get_state_absorb_gauges(self):
+        # the three absorb_gauges modes should all describe the same state
+        edges = [(0, 1), (1, 2), (0, 2)]
+        circ = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=8)
+        circ.apply_gates(
+            [
+                qtn.Gate("H", params=(), qubits=[0]),
+                qtn.Gate("CNOT", params=(), qubits=[0, 1]),
+                qtn.Gate("CZ", params=(), qubits=[1, 2]),
+            ]
+        )
+        # absorbed network is exactly the `psi` property
+        psi_absorbed = circ.get_state(absorb_gauges=True)
+        assert_allclose(psi_absorbed.to_dense(), circ.psi.to_dense())
+        # gauges added but uncontracted should give the same dense state
+        psi_uncontracted = circ.get_state(absorb_gauges=False)
+        assert qu.fidelity(
+            psi_uncontracted.to_dense(), psi_absorbed.to_dense()
+        ) == pytest.approx(1.0, abs=1e-10)
+        # "return" hands back the raw network plus a copy of the gauges
+        raw, gauges = circ.get_state(absorb_gauges="return")
+        assert set(gauges) == set(circ.gauges)
+        assert gauges is not circ.gauges
+        raw.gauge_simple_insert(gauges)
+        assert qu.fidelity(
+            raw.to_dense(), psi_absorbed.to_dense()
+        ) == pytest.approx(1.0, abs=1e-10)
 
     def test_local_expectation_on_grid_coordinate_sites(self):
         # sites are 2D coordinate tuples; a single-site `where` must not be

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -837,6 +837,185 @@ class TestCircuitMPS:
         assert set(circ.sample(10, seed=42)) == {"0100"}
 
 
+class TestCircuitPEPSSimpleUpdate:
+    def test_requires_edges(self):
+        with pytest.raises(ValueError):
+            qtn.CircuitPEPSSimpleUpdate()
+
+    def test_construction_and_initial_state(self):
+        # 2x3 grid of integer-labelled sites
+        edges = [(0, 1), (1, 2), (3, 4), (4, 5), (0, 3), (1, 4), (2, 5)]
+        circ = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=8)
+        # one tensor per site, bonds only on the edges, all bond dim 1
+        assert circ.N == 6
+        assert circ._psi.max_bond() == 1
+        assert circ.psi.norm() == pytest.approx(1.0)
+
+    def test_target_api(self):
+        # the exact usage requested in the issue, on a 3x3 grid of integer sites
+        ncol = 3
+        edges = []
+        for r in range(3):
+            for c in range(3):
+                s = r * ncol + c
+                if c + 1 < 3:
+                    edges.append((s, s + 1))
+                if r + 1 < 3:
+                    edges.append((s, s + ncol))
+        rng = np.random.default_rng(42)
+        gates = [
+            qtn.Gate(
+                "U3", params=rng.uniform(0, 2 * np.pi, size=3), qubits=[i]
+            )
+            for i in range(9)
+        ]
+        gates += [
+            qtn.Gate("CZ", params=(), qubits=list(edge)) for edge in edges
+        ]
+        circ = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=8)
+        circ.apply_gates(gates)
+        peps = circ.psi
+        assert peps.max_bond() <= 8
+        assert peps.num_tensors == 9
+
+    def test_matches_exact_on_a_chain(self):
+        # on a chain, simple update at large bond is exact, so local
+        # expectations should match a dense Circuit to high precision
+        N = 5
+        edges = qtn.edges_1d_chain(N, cyclic=False)
+        rng = np.random.default_rng(0)
+
+        gates = []
+        for i in range(N):
+            gates.append(
+                qtn.Gate("RY", params=[rng.uniform(0, np.pi)], qubits=[i])
+            )
+        for i, j in edges:
+            gates.append(qtn.Gate("CNOT", params=(), qubits=[i, j]))
+            gates.append(
+                qtn.Gate("RZ", params=[rng.uniform(0, np.pi)], qubits=[j])
+            )
+            gates.append(qtn.Gate("CNOT", params=(), qubits=[i, j]))
+
+        circ_su = qtn.CircuitPEPSSimpleUpdate(
+            edges=edges, max_bond=32, cutoff=1e-12
+        )
+        circ_su.apply_gates(gates)
+        circ_su.equilibrate()
+
+        circ_exact = qtn.Circuit(N=N)
+        circ_exact.apply_gates(gates)
+
+        Z = qu.pauli("Z").astype(complex)
+        for i in range(N):
+            x_su = circ_su.local_expectation(Z, i, max_distance=N)
+            x_ex = circ_exact.local_expectation(Z, i)
+            assert float(np.real(x_su)) == pytest.approx(
+                float(np.real(x_ex)), abs=1e-8
+            )
+
+    def test_equilibrate_preserves_expectations(self):
+        N = 4
+        edges = qtn.edges_1d_chain(N, cyclic=False)
+        rng = np.random.default_rng(7)
+        gates = [
+            qtn.Gate("RY", params=[rng.uniform(0, np.pi)], qubits=[i])
+            for i in range(N)
+        ]
+        for i, j in edges:
+            gates.append(qtn.Gate("CNOT", params=(), qubits=[i, j]))
+
+        circ = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=32)
+        circ.apply_gates(gates)
+
+        Z = qu.pauli("Z").astype(complex)
+        before = [
+            float(np.real(circ.local_expectation(Z, i, max_distance=N)))
+            for i in range(N)
+        ]
+        circ.equilibrate()
+        after = [
+            float(np.real(circ.local_expectation(Z, i, max_distance=N)))
+            for i in range(N)
+        ]
+        for b, a in zip(before, after):
+            assert b == pytest.approx(a, abs=1e-8)
+
+    def test_matches_exact_on_2x2_plaquette(self):
+        # a 2x2 grid has a 4-cycle, so simple update is genuinely approximate,
+        # but a shallow circuit still matches exact closely. checks both
+        # local_expectation and the gauge-absorbed psi.
+        edges = [(0, 1), (2, 3), (0, 2), (1, 3)]
+        rng = np.random.default_rng(3)
+        gates = [
+            qtn.Gate("RY", params=[rng.uniform(0, np.pi)], qubits=[i])
+            for i in range(4)
+        ]
+        for i, j in edges:
+            gates.append(qtn.Gate("CZ", params=(), qubits=[i, j]))
+
+        circ = qtn.CircuitPEPSSimpleUpdate(
+            edges=edges, max_bond=16, cutoff=1e-12
+        )
+        circ.apply_gates(gates)
+
+        circ_exact = qtn.Circuit(N=4)
+        circ_exact.apply_gates(gates)
+
+        Z = qu.pauli("Z").astype(complex)
+        # gauge-absorbed psi should be a normalized state
+        psi = circ.psi
+        assert ((psi.H & psi) ^ all) == pytest.approx(1.0, abs=1e-6)
+
+        for i in range(4):
+            x_su = circ.local_expectation(Z, i, max_distance=4)
+            # measure the same way directly on the returned psi
+            x_psi = psi.compute_local_expectation_cluster(
+                {(i,): Z}, max_distance=4, normalized=True
+            )
+            x_ex = circ_exact.local_expectation(Z, i)
+            assert float(np.real(x_su)) == pytest.approx(
+                float(np.real(x_ex)), abs=1e-6
+            )
+            assert float(np.real(x_psi)) == pytest.approx(
+                float(np.real(x_ex)), abs=1e-6
+            )
+
+    def test_psi_access_does_not_mutate_gauges(self):
+        edges = [(0, 1), (1, 2)]
+        circ = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=8)
+        circ.apply_gates(
+            [
+                qtn.Gate("H", params=(), qubits=[0]),
+                qtn.Gate("CNOT", params=(), qubits=[0, 1]),
+                qtn.Gate("CNOT", params=(), qubits=[1, 2]),
+            ]
+        )
+        before = {k: np.asarray(v).copy() for k, v in circ.gauges.items()}
+        _ = circ.psi
+        _ = circ.psi
+        assert set(circ.gauges) == set(before)
+        for k in before:
+            assert_allclose(np.asarray(circ.gauges[k]), before[k])
+
+    def test_controlled_and_exact_methods_raise(self):
+        edges = [(0, 1), (1, 2)]
+        circ = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=8)
+        # controlled gates can't be expressed by the simple update rule
+        with pytest.raises(ValueError):
+            circ.apply_gates(
+                [qtn.Gate("X", params=(), qubits=[2], controls=[0])]
+            )
+        # exact-state methods are not meaningful for a gauged approximate state
+        circ.apply_gates([qtn.Gate("H", params=(), qubits=[0])])
+        with pytest.raises(NotImplementedError):
+            circ.to_dense()
+        with pytest.raises(NotImplementedError):
+            circ.amplitude("000")
+        with pytest.raises(NotImplementedError):
+            list(circ.sample(2))
+
+
 class TestCircuitGen:
     @pytest.mark.parametrize(
         "ansatz,cyclic",

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -838,9 +838,66 @@ class TestCircuitMPS:
 
 
 class TestCircuitPEPSSimpleUpdate:
-    def test_requires_edges(self):
+    def test_requires_geometry(self):
+        # none of edges, gates or psi0 given -> cannot define the geometry
         with pytest.raises(ValueError):
             qtn.CircuitPEPSSimpleUpdate()
+
+    def test_geometry_inferred_from_gates(self):
+        # passing the two-qubit gates instead of edges should reconstruct the
+        # same geometry, and give the same state as the explicit-edges path
+        edges = [(0, 1), (1, 2), (0, 2)]
+        rng = np.random.default_rng(5)
+        gates = [
+            qtn.Gate("RY", params=[rng.uniform(0, np.pi)], qubits=[i])
+            for i in range(3)
+        ]
+        gates += [qtn.Gate("CZ", params=(), qubits=list(e)) for e in edges]
+
+        circ_edges = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=16)
+        circ_gates = qtn.CircuitPEPSSimpleUpdate(gates=gates, max_bond=16)
+        # geometry matches (as undirected edges) and the gates are not applied
+        assert {frozenset(e) for e in circ_gates.edges} == {
+            frozenset(e) for e in circ_edges.edges
+        }
+        assert circ_gates.num_gates == 0
+
+        circ_edges.apply_gates(gates)
+        circ_gates.apply_gates(gates)
+        Z = qu.pauli("Z").astype(complex)
+        for i in range(3):
+            xe = circ_edges.local_expectation(Z, i, max_distance=3)
+            xg = circ_gates.local_expectation(Z, i, max_distance=3)
+            assert float(np.real(xg)) == pytest.approx(
+                float(np.real(xe)), abs=1e-10
+            )
+
+    def test_geometry_inferred_from_psi0(self):
+        # build a state, hand it back as psi0, and check the geometry is read
+        # from its bonds and expectations are preserved
+        edges = [(0, 1), (1, 2), (2, 3), (3, 0)]
+        rng = np.random.default_rng(11)
+        gates = [
+            qtn.Gate("RY", params=[rng.uniform(0, np.pi)], qubits=[i])
+            for i in range(4)
+        ]
+        gates += [qtn.Gate("CZ", params=(), qubits=list(e)) for e in edges]
+
+        circ = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=16)
+        circ.apply_gates(gates)
+        psi = circ.psi
+
+        circ2 = qtn.CircuitPEPSSimpleUpdate(psi0=psi, max_bond=16)
+        assert {frozenset(e) for e in circ2.edges} == {
+            frozenset(e) for e in edges
+        }
+        Z = qu.pauli("Z").astype(complex)
+        for i in range(4):
+            x1 = circ.local_expectation(Z, i, max_distance=4)
+            x2 = circ2.local_expectation(Z, i, max_distance=4)
+            assert float(np.real(x2)) == pytest.approx(
+                float(np.real(x1)), abs=1e-6
+            )
 
     def test_construction_and_initial_state(self):
         # 2x3 grid of integer-labelled sites

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -1109,6 +1109,23 @@ class TestCircuitPEPSSimpleUpdate:
             xe = complex(ref.local_expectation(Z, qmap[s]))
             assert complex(x) == pytest.approx(xe, abs=1e-6)
 
+    def test_local_expectation_accepts_list_where(self):
+        # a multi-site `where` given as a list must not crash on the set
+        # membership check, and should match the tuple form
+        edges = [(0, 1), (1, 2)]
+        circ = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=8)
+        circ.apply_gates(
+            [
+                qtn.Gate("H", params=(), qubits=[0]),
+                qtn.Gate("CNOT", params=(), qubits=[0, 1]),
+            ]
+        )
+        Z = qu.pauli("Z").astype(complex)
+        ZZ = qu.kron(Z, Z)
+        x_list = circ.local_expectation(ZZ, [0, 1], max_distance=2)
+        x_tuple = circ.local_expectation(ZZ, (0, 1), max_distance=2)
+        assert complex(x_list) == pytest.approx(complex(x_tuple))
+
     def test_copy_is_independent(self):
         edges = qtn.edges_2d_square(2, 2)
         circ = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=8)

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -1071,6 +1071,149 @@ class TestCircuitPEPSSimpleUpdate:
             circ.amplitude("000")
         with pytest.raises(NotImplementedError):
             list(circ.sample(2))
+        with pytest.raises(NotImplementedError):
+            circ.partial_trace([0])
+        with pytest.raises(NotImplementedError):
+            circ.sample_chaotic_rehearse()
+        with pytest.raises(NotImplementedError):
+            circ.uni
+        # a two-qubit gate off any declared edge is rejected
+        with pytest.raises(ValueError):
+            circ.apply_gates([qtn.Gate("CZ", params=(), qubits=[0, 2])])
+
+    def test_local_expectation_on_grid_coordinate_sites(self):
+        # sites are 2D coordinate tuples; a single-site `where` must not be
+        # misread as a two-site operator (regression for the site handling)
+        edges = qtn.edges_2d_square(2, 2)
+        sites = sorted({s for e in edges for s in e})
+        rng = np.random.default_rng(0)
+        gates = [
+            (qu.rand_uni(2, seed=int(rng.integers(1 << 30))), s) for s in sites
+        ]
+        gates += [
+            (qu.rand_uni(4, seed=int(rng.integers(1 << 30))), a, b)
+            for a, b in edges
+        ]
+        circ = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=16)
+        circ.apply_gates(gates)
+        circ.equilibrate(max_iterations=300, tol=1e-12)
+
+        qmap = {s: i for i, s in enumerate(sites)}
+        ref = qtn.Circuit(N=len(sites))
+        for G, *where in gates:
+            ref.apply_gate(G, *(qmap[s] for s in where))
+
+        Z = qu.pauli("Z").astype(complex)
+        for s in sites:
+            x = circ.local_expectation(Z, s, max_distance=2)
+            xe = complex(ref.local_expectation(Z, qmap[s]))
+            assert complex(x) == pytest.approx(xe, abs=1e-6)
+
+    def test_copy_is_independent(self):
+        edges = qtn.edges_2d_square(2, 2)
+        circ = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=8)
+        rng = np.random.default_rng(3)
+        circ.apply_gates(
+            [
+                (qu.rand_uni(4, seed=int(rng.integers(1 << 30))), a, b)
+                for a, b in edges
+            ]
+        )
+        other = circ.copy()
+        n_before = circ.num_gates
+        # the copy carries the geometry and gauges and is independently usable
+        assert set(other.edges) == set(circ.edges)
+        assert other.gauges is not circ.gauges
+        assert len(other.gauges) == len(circ.gauges)
+        a, b = circ.edges[0]
+        other.apply_gates([(qu.rand_uni(4), a, b)])
+        # mutating the copy must not touch the original
+        assert circ.num_gates == n_before
+        assert other.num_gates == n_before + 1
+
+    def test_renorm_and_equilibrate_every(self):
+        # the renorm and equilibrate_every options should be accepted and keep
+        # normalized expectations correct on a chain (where SU is exact)
+        N = 5
+        edges = qtn.edges_1d_chain(N, cyclic=False)
+        rng = np.random.default_rng(1)
+        gates = [
+            (qu.rand_uni(2, seed=int(rng.integers(1 << 30))), i)
+            for i in range(N)
+        ]
+        gates += [
+            (qu.rand_uni(4, seed=int(rng.integers(1 << 30))), a, b)
+            for a, b in edges
+        ]
+        circ = qtn.CircuitPEPSSimpleUpdate(
+            edges=edges,
+            max_bond=32,
+            cutoff=1e-12,
+            renorm=True,
+            equilibrate_every=3,
+        )
+        circ.apply_gates(gates)
+        circ.equilibrate()
+
+        exact = qtn.Circuit(N=N)
+        exact.apply_gates(gates)
+        Z = qu.pauli("Z").astype(complex)
+        for i in range(N):
+            x = circ.local_expectation(Z, i, max_distance=N)
+            xe = complex(exact.local_expectation(Z, i))
+            assert complex(x) == pytest.approx(xe, abs=1e-8)
+
+    def test_cluster_error_decreases_with_distance(self):
+        # on a loopy lattice with an essentially exact (large max_bond) state,
+        # a larger cluster must give a more accurate local expectation
+        edges = qtn.edges_2d_square(3, 3)
+        sites = sorted({s for e in edges for s in e})
+        rng = np.random.default_rng(11)
+        gates = [
+            (qu.rand_uni(2, seed=int(rng.integers(1 << 30))), s) for s in sites
+        ]
+        gates += [
+            (qu.rand_uni(4, seed=int(rng.integers(1 << 30))), a, b)
+            for a, b in edges
+        ]
+        qmap = {s: i for i, s in enumerate(sites)}
+        ref = qtn.Circuit(N=len(sites))
+        for G, *where in gates:
+            ref.apply_gate(G, *(qmap[s] for s in where))
+        Z = qu.pauli("Z").astype(complex)
+        exact = {s: complex(ref.local_expectation(Z, qmap[s])) for s in sites}
+
+        circ = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=16)
+        circ.apply_gates(gates)
+        circ.equilibrate(max_iterations=200, tol=1e-10)
+
+        def err(md):
+            return max(
+                abs(circ.local_expectation(Z, s, max_distance=md) - exact[s])
+                for s in sites
+            )
+
+        assert err(3) < err(0)
+
+    def test_scales_to_a_larger_lattice(self):
+        # the point of a PEPS simulator: run a circuit on a lattice far too
+        # large to simulate exactly, with the bond dimension capped
+        edges = qtn.edges_2d_square(6, 6)
+        max_bond = 8
+        circ = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=max_bond)
+        sites = sorted({s for e in edges for s in e})
+        rng = np.random.default_rng(2)
+        gates = [
+            (qu.rand_uni(2, seed=int(rng.integers(1 << 30))), s) for s in sites
+        ]
+        gates += [
+            (qu.rand_uni(4, seed=int(rng.integers(1 << 30))), a, b)
+            for a, b in edges
+        ]
+        circ.apply_gates(gates)
+        psi = circ.psi
+        assert psi.num_tensors == len(sites)
+        assert psi.max_bond() <= max_bond
 
 
 class TestCircuitGen:


### PR DESCRIPTION
Closes #358.

## What

Adds `qtn.CircuitPEPSSimpleUpdate`, a `Circuit` subclass that keeps the state as a PEPS over an arbitrary graph of `edges` and applies gates with the simple update rule, as requested in #358.

```python
circ = qtn.CircuitPEPSSimpleUpdate(edges=edges, max_bond=16)
circ.apply_gates(gates)
peps = circ.psi
```

## How

- State is a `TensorNetworkGenVector` |00...0> product state with bond-dimension-1 bonds on the edges. Gates route through `gate_simple_`, tracking Vidal-form bond gauges in `self.gauges`. Mirrors the `CircuitMPS` / `CircuitPermMPS` override points.
- Geometry can be given as `edges`, inferred from the supplied `gates` or read from a `psi0` (whose bond gauges are then seeded).
- `equilibrate()` re-gauges with `gauge_all_simple_`; `equilibrate_every` does it automatically. `renorm=False` tracks the norm for the near-identity gates of time evolution (the linked real-time simple update example).
- `local_expectation(G, where, max_distance=...)` uses `compute_local_expectation_cluster`.
- `psi` returns the gauge-absorbed state; `psi_gauged` keeps the gauges separate.

## Scope choices (happy to adjust)

- Exact-state inherited methods (`to_dense`, `amplitude`, `sample`, `partial_trace`, `uni`, reverse lightcone) raise rather than silently contract an un-gauged state, following `CircuitDense`. Glad to add gauged versions of any if you want them.
- Controlled / special gates raise, since simple update applies a dense gate to the sites.

## Tests

16 tests: the target API, three geometry inputs, chain correctness vs exact (1e-8), a 2x2 plaquette vs exact (1e-6), grid-coordinate observables, `equilibrate` invariance, the cluster error decreasing with `max_distance`, `copy` independence, a 6x6 scalability run and the raising paths. Full `test_circuit.py` passes (89 passed). ruff check and format clean.

## AI disclosure

This change was implemented with substantial help from Claude (Anthropic). Claude drafted the class and tests and proposed the design: mirror `CircuitMPS` and `CircuitPermMPS`, infer the geometry three ways, raise on the exact-state methods rather than leave them silently wrong, track the gauges in `self.gauges`. I reviewed those choices, which are documented above. Verified locally before submitting: the chain and plaquette match exact simulation, the cluster error converges with cluster size, `test_circuit.py` passes (89) and ruff is clean.
