### PR TITLE
Add CircuitMPSLazy for lazy MPS compression circuit simulation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ Release notes for `quimb`.
 - [`TensorNetwork.gauge_all_simple`](quimb.tensor.tensor_core.TensorNetwork.gauge_all_simple): add a ``fuse_multibonds`` option for updating gauges while preserving multi-index bonds, supported by explicit bond-index selection in [`tensor_compress_bond`](quimb.tensor.tensor_core.tensor_compress_bond).
 - add [`LatticeBondMap`](quimb.tensor.tnag.core.LatticeBondMap): helper for consistently assigning lattice bond indices across ordinary and periodic boundaries, use it in PEPS, PEPO, PEPS3D, scalar 2D/3D lattice tensor-network construction, and classical Ising tensor-network construction.
 - [`eigh_truncated`](quimb.tensor.decomp.eigh_truncated): add a ``shift`` option for optional diagonal regularization.
+- add [`CircuitMPSLazy`](quimb.tensor.circuit.CircuitMPSLazy): a matrix product state circuit simulator that applies gates lazily as split sub-MPOs and only periodically performs a global compression with [`tensor_network_1d_compress`](quimb.tensor.tn1d.compress.tensor_network_1d_compress).
 
 
 **Bug fixes:**

--- a/quimb/tensor/__init__.py
+++ b/quimb/tensor/__init__.py
@@ -4,6 +4,7 @@ from .circuit import (
     Circuit,
     CircuitDense,
     CircuitMPS,
+    CircuitMPSLazy,
     CircuitPermMPS,
     Gate,
 )
@@ -241,6 +242,7 @@ __all__ = (
     "Circuit",
     "CircuitDense",
     "CircuitMPS",
+    "CircuitMPSLazy",
     "CircuitPermMPS",
     "cnf_file_parse",
     "connect",

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -5916,13 +5916,14 @@ class CircuitMPSLazy(CircuitMPS):
     :func:`~quimb.tensor.tn1d.compress.tensor_network_1d_compress`.
 
     Unlike the eager, TEBD style :class:`CircuitMPS`, which compresses the state
-    after every gate, gates here are stacked without contraction until a new
-    gate would act on a site that already carries an uncompressed gate, at which
-    point a global compression is triggered first. Batching gates into layers
-    before a single global compression can be more accurate, and scale better,
-    than compressing pair by pair, particularly for long range gates. It also
-    allows switching out the underlying compression algorithm, including newer
-    ones such as ``"src"`` (successive randomized compression).
+    after every gate, multi-qubit gates here are stacked without contraction
+    until a new gate would take a site past ``compress_every`` uncompressed
+    gates, at which point a global compression is triggered first. Single qubit
+    gates are always contracted in eagerly, since they grow no bonds. Batching
+    gates into layers before a single global compression can be more accurate,
+    and scale better, than compressing pair by pair, particularly for long range
+    gates. It also allows switching out the underlying compression algorithm,
+    including newer ones such as ``"src"`` (successive randomized compression).
 
     The state is flushed (a final compression is performed if any gates are
     pending) whenever :attr:`psi`, :meth:`sample`, :meth:`local_expectation` or
@@ -5946,10 +5947,16 @@ class CircuitMPSLazy(CircuitMPS):
         :func:`~quimb.tensor.tn1d.compress.tensor_network_1d_compress`. Common
         options are ``"dm"`` (default), ``"direct"``, ``"zipup"``, ``"fit"``
         and ``"src"``.
+    compress_every : int, optional
+        Allow each site to accumulate this many uncompressed multi-qubit gates
+        before forcing a global compression. The default of 1 compresses once a
+        gate would overlap a previous uncompressed gate (i.e. roughly once per
+        layer); larger values defer compression across more layers.
     compress_opts : dict, optional
-        Supplied to
-        :func:`~quimb.tensor.tn1d.compress.tensor_network_1d_compress` at each
-        compression.
+        The single source of truth for the compression options. ``max_bond``,
+        ``cutoff`` and ``method`` are stored here, and any extra options are
+        forwarded to
+        :func:`~quimb.tensor.tn1d.compress.tensor_network_1d_compress`.
     dtype : str, optional
         The data type to use for the state tensor.
     to_backend : callable, optional
@@ -5988,31 +5995,64 @@ class CircuitMPSLazy(CircuitMPS):
         max_bond=None,
         cutoff=1e-10,
         method="dm",
+        compress_every=1,
         compress_opts=None,
         dtype=None,
         to_backend=None,
         convert_eager=True,
         **circuit_opts,
     ):
-        self._method = method
-        self._max_bond = max_bond
-        self._cutoff = cutoff
-        self._compress_opts = ensure_dict(compress_opts)
+        # compress_opts is the single source of truth for the compression
+        # parameters, populated from the convenience kwargs if not given there
+        self.compress_opts = ensure_dict(compress_opts)
+        self.compress_opts.setdefault("max_bond", max_bond)
+        self.compress_opts.setdefault("cutoff", cutoff)
+        self.compress_opts.setdefault("method", method)
+        self.compress_every = compress_every
         # whether any gates have been stacked since the last compression
         self._pending = False
-        # sites carrying uncompressed multi-qubit gates, used to decide when
-        # the next gate should force a compression
-        self._uncompressed = set()
+        # per-site count of stacked, uncompressed multi-qubit gates, used to
+        # decide when the next gate should force a compression
+        self._touch_count = {}
         super().__init__(
             N,
             psi0=psi0,
-            max_bond=max_bond,
-            cutoff=cutoff,
+            max_bond=self.compress_opts["max_bond"],
+            cutoff=self.compress_opts["cutoff"],
             dtype=dtype,
             to_backend=to_backend,
             convert_eager=convert_eager,
             **circuit_opts,
         )
+
+    @property
+    def max_bond(self):
+        """The maximum bond dimension to compress to."""
+        return self.compress_opts["max_bond"]
+
+    @max_bond.setter
+    def max_bond(self, value):
+        self.compress_opts["max_bond"] = value
+        self.gate_opts["max_bond"] = value
+
+    @property
+    def cutoff(self):
+        """The singular value cutoff to use when compressing."""
+        return self.compress_opts["cutoff"]
+
+    @cutoff.setter
+    def cutoff(self, value):
+        self.compress_opts["cutoff"] = value
+        self.gate_opts["cutoff"] = value
+
+    @property
+    def method(self):
+        """The compression method passed to ``tensor_network_1d_compress``."""
+        return self.compress_opts["method"]
+
+    @method.setter
+    def method(self, value):
+        self.compress_opts["method"] = value
 
     def _compress(self):
         """Globally compress the accumulated lazy gates and the state back into
@@ -6024,22 +6064,20 @@ class CircuitMPSLazy(CircuitMPS):
 
         from .tn1d.compress import tensor_network_1d_compress
 
+        opts = self.compress_opts
         # the 'src' family ignores cutoff and warns if it is nonzero
-        cutoff = 0.0 if "src" in self._method else self._cutoff
+        if "src" in opts["method"] and opts.get("cutoff"):
+            opts = {**opts, "cutoff": 0.0}
 
-        self._psi = tensor_network_1d_compress(
-            self._psi,
-            max_bond=self._max_bond,
-            cutoff=cutoff,
-            method=self._method,
-            inplace=True,
-            **self._compress_opts,
-        )
-        # the compression moves the orthogonality center, so any position
-        # recorded by an earlier eager fallback gate is now stale
-        self.gate_opts["info"]["cur_orthog"] = None
+        self._psi = tensor_network_1d_compress(self._psi, inplace=True, **opts)
+        # tensor_network_1d_compress leaves the orthogonality center at the
+        # first site, or the last site if sweeping in reverse
+        if self.compress_opts.get("sweep_reverse", False):
+            self.gate_opts["info"]["cur_orthog"] = (self._psi.L - 1,) * 2
+        else:
+            self.gate_opts["info"]["cur_orthog"] = (0, 0)
         self._pending = False
-        self._uncompressed.clear()
+        self._touch_count.clear()
 
     def _apply_gate(self, gate, tags=None, **gate_opts):
         if gate.special or gate.controls:
@@ -6049,14 +6087,6 @@ class CircuitMPSLazy(CircuitMPS):
             return super()._apply_gate(gate, tags=tags, **gate_opts)
 
         where = gate.qubits
-        multi = len(where) >= 2
-
-        if multi:
-            span = set(range(min(where), max(where) + 1))
-            # compress first if this gate would stack onto a site that already
-            # carries an uncompressed multi-qubit gate
-            if not self._uncompressed.isdisjoint(span):
-                self._compress()
 
         G = gate.array
         if self.convert_eager:
@@ -6065,12 +6095,29 @@ class CircuitMPSLazy(CircuitMPS):
                 self._backend_gate_cache[key] = self._maybe_convert(G)
             G = self._backend_gate_cache[key]
 
+        if len(where) == 1:
+            # a single qubit unitary can be contracted directly into the tensor
+            # currently carrying that site's output index: it changes neither
+            # the geometry nor the orthogonality center, so needs no compression
+            self._psi.gate_inds_(
+                G, (self._psi.site_ind(where[0]),), contract=True
+            )
+            self._gates.append(gate)
+            return
+
+        span = range(min(where), max(where) + 1)
+        # compress first if stacking this gate would take any of its sites past
+        # ``compress_every`` uncompressed multi-qubit gates
+        if any(
+            self._touch_count.get(s, 0) >= self.compress_every for s in span
+        ):
+            self._compress()
+
         # stack the gate as a split sub-MPO without any compression
         self._psi.gate_nonlocal_(G, where, method="lazy")
         self._pending = True
-
-        if multi:
-            self._uncompressed |= span
+        for s in span:
+            self._touch_count[s] = self._touch_count.get(s, 0) + 1
 
         self._gates.append(gate)
 

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -4945,6 +4945,204 @@ class CircuitMPS(Circuit):
         )
 
 
+class CircuitMPSLazy(CircuitMPS):
+    r"""Quantum circuit simulation that keeps the state in MPS form, but applies
+    gates *lazily* as spatially split sub-MPOs, only periodically performing a
+    single global compression of the accumulated gates and state back into an
+    MPS using
+    :func:`~quimb.tensor.tn1d.compress.tensor_network_1d_compress`.
+
+    Unlike the eager, TEBD style :class:`CircuitMPS`, which compresses the state
+    after every gate, gates here are stacked without contraction until a new
+    gate would act on a site that already carries an uncompressed gate, at which
+    point a global compression is triggered first. Batching gates into layers
+    before a single global compression can be more accurate, and scale better,
+    than compressing pair by pair, particularly for long range gates. It also
+    allows switching out the underlying compression algorithm, including newer
+    ones such as ``"src"`` (successive randomized compression).
+
+    The state is flushed (a final compression is performed if any gates are
+    pending) whenever :attr:`psi`, :meth:`sample`, :meth:`local_expectation` or
+    :meth:`fidelity_estimate` are requested, so the returned state is always a
+    genuine MPS. Note that, unlike :class:`CircuitMPS`, per-gate options are not
+    forwarded to the lazily stacked gates; the compression is controlled by
+    ``max_bond``, ``cutoff``, ``method`` and ``compress_opts`` instead.
+
+    Parameters
+    ----------
+    N : int, optional
+        The number of qubits in the circuit.
+    psi0 : TensorNetwork1DVector, optional
+        The initial state, assumed to be ``|00000....0>`` if not given.
+    max_bond : int, optional
+        The maximum bond dimension to compress to at each compression.
+    cutoff : float, optional
+        The singular value cutoff to use when compressing.
+    method : str, optional
+        The compression method to use, passed to
+        :func:`~quimb.tensor.tn1d.compress.tensor_network_1d_compress`. Common
+        options are ``"dm"`` (default), ``"direct"``, ``"zipup"``, ``"fit"``
+        and ``"src"``.
+    compress_opts : dict, optional
+        Supplied to
+        :func:`~quimb.tensor.tn1d.compress.tensor_network_1d_compress` at each
+        compression.
+    dtype : str, optional
+        The data type to use for the state tensor.
+    to_backend : callable, optional
+        A function to convert tensor data to a particular backend.
+    convert_eager : bool, optional
+        Whether to eagerly perform dtype casting and application of
+        ``to_backend`` as gates are supplied.
+    circuit_opts
+        Supplied to :class:`~quimb.tensor.circuit.Circuit`.
+
+    Attributes
+    ----------
+    psi : MatrixProductState
+        The current state of the circuit, flushed to MPS form on access.
+
+    Examples
+    --------
+
+    Simulate a circuit, compressing accumulated gates with the successive
+    randomized compression method::
+
+        circ = qtn.CircuitMPSLazy(N=56, max_bond=512, method="src")
+        circ.apply_gates(gates)
+        mps = circ.psi
+
+    See Also
+    --------
+    CircuitMPS
+    """
+
+    def __init__(
+        self,
+        N=None,
+        *,
+        psi0=None,
+        max_bond=None,
+        cutoff=1e-10,
+        method="dm",
+        compress_opts=None,
+        dtype=None,
+        to_backend=None,
+        convert_eager=True,
+        **circuit_opts,
+    ):
+        self._method = method
+        self._max_bond = max_bond
+        self._cutoff = cutoff
+        self._compress_opts = ensure_dict(compress_opts)
+        # whether any gates have been stacked since the last compression
+        self._pending = False
+        # sites carrying uncompressed multi-qubit gates, used to decide when
+        # the next gate should force a compression
+        self._uncompressed = set()
+        super().__init__(
+            N,
+            psi0=psi0,
+            max_bond=max_bond,
+            cutoff=cutoff,
+            dtype=dtype,
+            to_backend=to_backend,
+            convert_eager=convert_eager,
+            **circuit_opts,
+        )
+
+    def _compress(self):
+        """Globally compress the accumulated lazy gates and the state back into
+        a single MPS, then reset the pending gate tracking. Does nothing if no
+        gates are currently pending.
+        """
+        if not self._pending:
+            return
+
+        from .tn1d.compress import tensor_network_1d_compress
+
+        # the 'src' family ignores cutoff and warns if it is nonzero
+        cutoff = 0.0 if "src" in self._method else self._cutoff
+
+        self._psi = tensor_network_1d_compress(
+            self._psi,
+            max_bond=self._max_bond,
+            cutoff=cutoff,
+            method=self._method,
+            inplace=True,
+            **self._compress_opts,
+        )
+        # the compression moves the orthogonality center, so any position
+        # recorded by an earlier eager fallback gate is now stale
+        self.gate_opts["info"]["cur_orthog"] = None
+        self._pending = False
+        self._uncompressed.clear()
+
+    def _apply_gate(self, gate, tags=None, **gate_opts):
+        if gate.special or gate.controls:
+            # not a plain dense gate (e.g. function-based or controlled): flush
+            # any pending gates then fall back to eager MPS application
+            self._compress()
+            return super()._apply_gate(gate, tags=tags, **gate_opts)
+
+        where = gate.qubits
+        multi = len(where) >= 2
+
+        if multi:
+            span = set(range(min(where), max(where) + 1))
+            # compress first if this gate would stack onto a site that already
+            # carries an uncompressed multi-qubit gate
+            if not self._uncompressed.isdisjoint(span):
+                self._compress()
+
+        G = gate.array
+        if self.convert_eager:
+            key = id(G)
+            if key not in self._backend_gate_cache:
+                self._backend_gate_cache[key] = self._maybe_convert(G)
+            G = self._backend_gate_cache[key]
+
+        # stack the gate as a split sub-MPO without any compression
+        self._psi.gate_nonlocal_(G, where, method="lazy")
+        self._pending = True
+
+        if multi:
+            self._uncompressed |= span
+
+        self._gates.append(gate)
+
+    def apply_gates(self, gates, progbar=False, **gate_opts):
+        if progbar:
+            from ..utils import progbar as _progbar
+
+            gates = tuple(gates)
+            gates = _progbar(gates, total=len(gates))
+
+        for gate in gates:
+            self._apply_gate(parse_to_gate(gate), **gate_opts)
+
+            if progbar:
+                gates.set_description(f"max_bond={self._psi.max_bond()}")
+
+    @property
+    def psi(self):
+        # flush any pending lazy gates so the returned state is a genuine MPS
+        self._compress()
+        return super().psi
+
+    def sample(self, C, *args, **kwargs):
+        self._compress()
+        yield from super().sample(C, *args, **kwargs)
+
+    def local_expectation(self, G, where, *args, **kwargs):
+        self._compress()
+        return super().local_expectation(G, where, *args, **kwargs)
+
+    def fidelity_estimate(self):
+        self._compress()
+        return super().fidelity_estimate()
+
+
 class CircuitPermMPS(CircuitMPS):
     """Quantum circuit simulation keeping the state always in an MPS form, but
     lazily tracking the qubit ordering rather than 'swapping back' qubits after

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -1563,7 +1563,9 @@ class TestCircuitMPSLazy:
                 )
         return gates
 
-    @pytest.mark.parametrize("method", ["dm", "direct", "zipup", "fit"])
+    @pytest.mark.parametrize(
+        "method", ["dm", "direct", "zipup", "fit", "src"]
+    )
     def test_matches_dense_with_long_range(self, method):
         N = 8
         gates = self._random_circuit_gates(
@@ -1594,18 +1596,35 @@ class TestCircuitMPSLazy:
 
         assert lazy.psi.distance_normalized(eager.psi) < 1e-6
 
-    def test_src_method_on_local_circuit(self):
-        # the 'src' compression method supports local (non system-spanning)
-        # circuits, which is the main use case for lazy compression
-        N = 8
-        gates = self._random_circuit_gates(N, depth=4, seed=7)
+    def test_compress_every(self):
+        # compress_every defers compression across more gate layers: the result
+        # is unchanged at full bond, but fewer compressions are performed
+        N = 6
+        gates = self._random_circuit_gates(N, depth=6, seed=7)
         ref = qtn.Circuit(N)
         ref.apply_gates(gates)
 
-        circ = qtn.CircuitMPSLazy(N, max_bond=2**N, method="src")
-        circ.apply_gates(gates)
+        def count_compressions(compress_every):
+            circ = qtn.CircuitMPSLazy(
+                N, max_bond=2**N, cutoff=1e-12, compress_every=compress_every
+            )
+            n = 0
+            real_compress = circ._compress
 
-        assert circ.psi.distance_normalized(ref.psi) < 1e-6
+            def counting():
+                nonlocal n
+                if circ._pending:
+                    n += 1
+                real_compress()
+
+            circ._compress = counting
+            circ.apply_gates(gates)
+            assert circ.psi.distance_normalized(ref.psi) < 1e-6
+            return n
+
+        n1 = count_compressions(1)
+        n3 = count_compressions(3)
+        assert n3 < n1
 
     def test_explicit_long_range_gate(self):
         N = 6

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -837,6 +837,274 @@ class TestCircuitMPS:
         assert set(circ.sample(10, seed=42)) == {"0100"}
 
 
+class TestCircuitMPSLazy:
+    @staticmethod
+    def _random_circuit_gates(N, depth, seed, long_range=False):
+        """A brickwork circuit of U3 and SU4 gates, optionally with an extra
+        long range two-qubit gate per layer."""
+        rng = np.random.default_rng(seed)
+        gates = []
+        for d in range(depth):
+            for i in range(N):
+                gates.append(
+                    qtn.Gate(
+                        "U3", params=rng.uniform(0, 2 * np.pi, 3), qubits=[i]
+                    )
+                )
+            for i in range(d % 2, N - 1, 2):
+                gates.append(
+                    qtn.Gate(
+                        "SU4",
+                        params=rng.uniform(0, 2 * np.pi, 15),
+                        qubits=[i, i + 1],
+                    )
+                )
+            if long_range:
+                a, b = sorted(
+                    map(int, rng.choice(N, size=2, replace=False))
+                )
+                gates.append(
+                    qtn.Gate.from_raw(
+                        qu.rand_uni(4, seed=int(rng.integers(1 << 30))),
+                        qubits=[a, b],
+                    )
+                )
+        return gates
+
+    @pytest.mark.parametrize("method", ["dm", "direct", "zipup", "fit"])
+    def test_matches_dense_with_long_range(self, method):
+        N = 8
+        gates = self._random_circuit_gates(
+            N, depth=3, seed=42, long_range=True
+        )
+        ref = qtn.Circuit(N)
+        ref.apply_gates(gates)
+
+        circ = qtn.CircuitMPSLazy(
+            N, max_bond=2**N, cutoff=1e-12, method=method
+        )
+        circ.apply_gates(gates)
+        mps = circ.psi
+
+        assert isinstance(mps, qtn.MatrixProductState)
+        assert mps.distance_normalized(ref.psi) < 1e-6
+        assert circ.fidelity_estimate() == pytest.approx(1.0, abs=1e-6)
+
+    def test_matches_eager_circuitmps(self):
+        N = 7
+        gates = self._random_circuit_gates(N, depth=3, seed=10)
+
+        eager = qtn.CircuitMPS(N, max_bond=2**N, cutoff=1e-12)
+        eager.apply_gates(gates)
+
+        lazy = qtn.CircuitMPSLazy(N, max_bond=2**N, cutoff=1e-12)
+        lazy.apply_gates(gates)
+
+        assert lazy.psi.distance_normalized(eager.psi) < 1e-6
+
+    def test_src_method_on_local_circuit(self):
+        # the 'src' compression method supports local (non system-spanning)
+        # circuits, which is the main use case for lazy compression
+        N = 8
+        gates = self._random_circuit_gates(N, depth=4, seed=7)
+        ref = qtn.Circuit(N)
+        ref.apply_gates(gates)
+
+        circ = qtn.CircuitMPSLazy(N, max_bond=2**N, method="src")
+        circ.apply_gates(gates)
+
+        assert circ.psi.distance_normalized(ref.psi) < 1e-6
+
+    def test_explicit_long_range_gate(self):
+        N = 6
+        gates = [
+            qtn.Gate("H", params=(), qubits=[0]),
+            qtn.Gate.from_raw(qu.rand_uni(4, seed=3), qubits=[0, N - 1]),
+            qtn.Gate("CX", params=(), qubits=[N - 1, 2]),
+        ]
+        ref = qtn.Circuit(N)
+        ref.apply_gates(gates)
+
+        circ = qtn.CircuitMPSLazy(N, max_bond=2**N)
+        circ.apply_gates(gates)
+
+        assert circ.psi.distance_normalized(ref.psi) < 1e-6
+
+    def test_single_qubit_gates_only(self):
+        N = 5
+        rng = np.random.default_rng(0)
+        gates = [
+            qtn.Gate("U3", params=rng.uniform(0, 2 * np.pi, 3), qubits=[i])
+            for _ in range(3)
+            for i in range(N)
+        ]
+        ref = qtn.Circuit(N)
+        ref.apply_gates(gates)
+
+        circ = qtn.CircuitMPSLazy(N, max_bond=8)
+        circ.apply_gates(gates)
+        mps = circ.psi
+
+        assert isinstance(mps, qtn.MatrixProductState)
+        # single qubit gates never grow the bond dimension
+        assert mps.max_bond() == 1
+        assert mps.distance_normalized(ref.psi) < 1e-6
+
+    def test_psi_is_bounded_mps(self):
+        N = 10
+        max_bond = 8
+        gates = self._random_circuit_gates(N, depth=6, seed=99)
+
+        circ = qtn.CircuitMPSLazy(N, max_bond=max_bond, method="dm")
+        circ.apply_gates(gates)
+        mps = circ.psi
+
+        assert isinstance(mps, qtn.MatrixProductState)
+        assert mps.max_bond() <= max_bond
+
+    def test_truncation_fidelity_increases_with_bond(self):
+        N = 10
+        gates = self._random_circuit_gates(N, depth=8, seed=5)
+
+        fids = []
+        for max_bond in [2, 4, 8, 16]:
+            circ = qtn.CircuitMPSLazy(N, max_bond=max_bond, method="dm")
+            circ.apply_gates(gates)
+            f = circ.fidelity_estimate()
+            assert 0.0 < f <= 1.0 + 1e-9
+            assert circ.error_estimate() == pytest.approx(1 - f)
+            fids.append(f)
+
+        # raising the bond dimension should never reduce the fidelity
+        for lo, hi in zip(fids, fids[1:]):
+            assert hi >= lo - 1e-9
+        assert fids[-1] > fids[0]
+
+    def test_controlled_gate_then_lazy_keeps_fidelity_valid(self):
+        # a controlled gate takes the eager fallback path and records an
+        # orthogonality center; later lazy gates trigger a compression that
+        # moves the center, so the recorded position must be cleared, else
+        # fidelity_estimate and local_expectation read the wrong canonical form
+        N = 6
+        rng = np.random.default_rng(3)
+        gates = [
+            qtn.Gate("U3", params=rng.uniform(0, 2 * np.pi, 3), qubits=[i])
+            for i in range(N)
+        ]
+        # controlled gate -> eager fallback path, records cur_orthog
+        gates.append(
+            qtn.Gate(
+                "SU4",
+                params=rng.uniform(0, 2 * np.pi, 15),
+                qubits=[2, 4],
+                controls=[0],
+            )
+        )
+        # then lazily stacked two-qubit gates -> a compression on flush
+        for i in range(0, N - 1, 2):
+            gates.append(
+                qtn.Gate(
+                    "SU4",
+                    params=rng.uniform(0, 2 * np.pi, 15),
+                    qubits=[i, i + 1],
+                )
+            )
+
+        ref = qtn.Circuit(N)
+        ref.apply_gates(gates)
+        psi_dense = ref.to_dense()
+
+        circ = qtn.CircuitMPSLazy(
+            N, max_bond=2**N, cutoff=1e-12, method="direct"
+        )
+        circ.apply_gates(gates)
+
+        # no truncation, so the state is essentially exact
+        assert circ.fidelity_estimate() == pytest.approx(1.0, abs=1e-6)
+        assert circ.error_estimate() == pytest.approx(0.0, abs=1e-6)
+
+        # local expectations must match the dense reference; a stale center
+        # would silently shift these
+        Z = qu.pauli("Z")
+        for q in range(N):
+            ref_z = qu.expec(qu.ikron(Z, [2] * N, q), psi_dense).real
+            assert circ.local_expectation(Z, q).real == pytest.approx(
+                ref_z, abs=1e-6
+            )
+
+    def test_lazy_defers_compression(self):
+        # a single layer of disjoint two-qubit gates should be stacked and only
+        # compressed once, on flush, rather than once per gate
+        N = 8
+        rng = np.random.default_rng(1)
+        circ = qtn.CircuitMPSLazy(N, max_bond=16, method="dm")
+
+        n_compress = 0
+        real_compress = circ._compress
+
+        def counting_compress():
+            nonlocal n_compress
+            if circ._pending:
+                n_compress += 1
+            real_compress()
+
+        circ._compress = counting_compress
+
+        for i in range(0, N - 1, 2):
+            circ.apply_gates(
+                [
+                    qtn.Gate(
+                        "SU4",
+                        params=rng.uniform(0, 2 * np.pi, 15),
+                        qubits=[i, i + 1],
+                    )
+                ]
+            )
+        # nothing compressed while the disjoint layer is being stacked
+        assert n_compress == 0
+
+        _ = circ.psi
+        # exactly one global compression performed on flush
+        assert n_compress == 1
+
+    def test_2d_ising_dynamics(self):
+        # small 2D transverse-field Ising Trotter dynamics mapped onto a 1D MPS;
+        # the vertical couplings are long range in the 1D ordering
+        Lx, Ly = 2, 3
+        N = Lx * Ly
+
+        def site(x, y):
+            return x * Ly + y
+
+        bonds = []
+        for x in range(Lx):
+            for y in range(Ly):
+                if y + 1 < Ly:
+                    bonds.append((site(x, y), site(x, y + 1)))
+                if x + 1 < Lx:
+                    bonds.append((site(x, y), site(x + 1, y)))
+
+        dt = 0.1
+        zz = qu.pauli("Z") & qu.pauli("Z")
+        rzz = qu.expm(-1j * dt * zz)
+        rx = qu.expm(-1j * dt * qu.pauli("X"))
+
+        gates = []
+        for _ in range(3):
+            for i in range(N):
+                gates.append(qtn.Gate.from_raw(rx, qubits=[i]))
+            for a, b in bonds:
+                gates.append(qtn.Gate.from_raw(rzz, qubits=[a, b]))
+
+        ref = qtn.Circuit(N)
+        ref.apply_gates(gates)
+
+        circ = qtn.CircuitMPSLazy(N, max_bond=2**N, cutoff=1e-12, method="dm")
+        circ.apply_gates(gates)
+
+        assert circ.psi.distance_normalized(ref.psi) < 1e-6
+
+
 class TestCircuitGen:
     @pytest.mark.parametrize(
         "ansatz,cyclic",


### PR DESCRIPTION
Closes #357.

This adds `CircuitMPSLazy`, a high level circuit simulator that keeps the state as an MPS but applies gates lazily and only compresses periodically, rather than after every gate like `CircuitMPS`.

### How it works

Each gate is stacked onto the state as a spatially split sub-MPO (using the existing `gate_nonlocal(..., method="lazy")` machinery), with no contraction. A global compression with `tensor_network_1d_compress` is triggered only when a new gate would act on a site that already carries an uncompressed multi-qubit gate, i.e. once a layer of non-overlapping gates has been stacked. The state is flushed (a final compression performed) whenever `psi`, `sample`, `local_expectation` or `fidelity_estimate` is read, so the returned object is always a genuine MPS.

The compression method is selectable (`dm` by default, plus `direct`, `zipup`, `fit`, `src`, ...), so newer algorithms such as SRC can be dropped in. `fidelity_estimate` / `error_estimate` track the accumulated truncation via the state norm, consistent with `CircuitMPS`.

### Usage

```python
circ = qtn.CircuitMPSLazy(N, max_bond=512, method="src")
circ.apply_gates(gates)
mps = circ.psi
```

### Tests

`TestCircuitMPSLazy` in `tests/test_tensor/test_circuit.py` covers correctness against the dense `Circuit` across compression methods (including long range gates), agreement with the eager `CircuitMPS`, bounded output bond dimension, truncation fidelity monotonicity, the deferred compression behaviour, a small 2D Ising Trotter dynamics case, and the controlled-gate-then-lazy path.

### Notes

- Controlled and special (function based) gates fall back to eager application after flushing, so all gate types are supported.
- The `src` family currently has trouble compressing networks with system spanning long range bonds (it is fine for local circuits). The default `dm` method handles long range gates accurately, so I kept the default as `dm`.

### AI disclosure

I used an AI coding assistant to help explore the quimb compression and gate APIs, draft the implementation and tests, and review the code. I designed the approach, checked every test against dense reference states, and verified the numerical results and the long range `src` limitation myself.
