### PR TITLE
feat(tensor): add CircuitPEPSSimpleUpdate, a PEPS circuit simulator 

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ Release notes for `quimb`.
 
 **Enhancements:**
 
+- add [`CircuitPEPSSimpleUpdate`](quimb.tensor.circuit.CircuitPEPSSimpleUpdate): a high level quantum circuit simulator that keeps the state as an arbitrary geometry PEPS, applying nearest-neighbor gates with 'simple update' style gauging. The geometry is given by a set of ``edges`` (or inferred from the gates), the accuracy is controlled by ``max_bond``, and gauges can be periodically re-equilibrated with ``equilibrate``. Local expectations are computed via the cluster approximation.
 - [`TensorNetwork.gauge_all_simple`](quimb.tensor.tensor_core.TensorNetwork.gauge_all_simple): add a ``fuse_multibonds`` option for updating gauges while preserving multi-index bonds, supported by explicit bond-index selection in [`tensor_compress_bond`](quimb.tensor.tensor_core.tensor_compress_bond).
 - add [`LatticeBondMap`](quimb.tensor.tnag.core.LatticeBondMap): helper for consistently assigning lattice bond indices across ordinary and periodic boundaries, use it in PEPS, PEPO, PEPS3D, scalar 2D/3D lattice tensor-network construction, and classical Ising tensor-network construction.
 - [`eigh_truncated`](quimb.tensor.decomp.eigh_truncated): add a ``shift`` option for optional diagonal regularization.

--- a/quimb/tensor/__init__.py
+++ b/quimb/tensor/__init__.py
@@ -4,6 +4,7 @@ from .circuit import (
     Circuit,
     CircuitDense,
     CircuitMPS,
+    CircuitPEPSSimpleUpdate,
     CircuitPermMPS,
     Gate,
 )
@@ -241,6 +242,7 @@ __all__ = (
     "Circuit",
     "CircuitDense",
     "CircuitMPS",
+    "CircuitPEPSSimpleUpdate",
     "CircuitPermMPS",
     "cnf_file_parse",
     "connect",

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -30,6 +30,8 @@ from .tensor_builder import (
     MPO_identity_like,
     MPS_computational_state,
     TN_from_sites_computational_state,
+    TN_from_sites_product_state,
+    gen_unique_edges,
 )
 from .tensor_core import (
     PTensor,
@@ -5102,5 +5104,325 @@ class CircuitDense(Circuit):
     def get_psi_reverse_lightcone(self, where, keep_psi0=False):
         """Override ``get_psi_reverse_lightcone`` as for a dense wavefunction
         the lightcone is not meaningful.
+        """
+        return self.psi
+
+
+class CircuitPEPSSimpleUpdate(Circuit):
+    """Quantum circuit simulation keeping the state as a PEPS (projected
+    entangled pair state) of arbitrary geometry, applying gates with 'simple
+    update' style gauging. The geometry is fixed by a set of ``edges`` and only
+    nearest neighbor (i.e. on-edge) two site gates are allowed. Gauges living on
+    the bonds are maintained separately and can be periodically re-equilibrated
+    with :meth:`equilibrate`. This is an approximate but scalable simulation
+    method - the accuracy is controlled by ``max_bond``.
+
+    Parameters
+    ----------
+    edges : sequence[tuple[hashable, hashable]], optional
+        The edges defining the PEPS geometry, i.e. which pairs of sites are
+        connected by a bond and thus where two site gates can be applied. Each
+        site can be any hashable label. If not given, ``gates`` or ``psi0``
+        must be supplied instead.
+    gates : sequence, optional
+        If ``edges`` is not given, infer the geometry from the two site gates in
+        this sequence (the gates are *not* applied, just inspected). This is a
+        convenience for circuits where the geometry is implied by the gates.
+    max_bond : int, optional
+        The maximum bond dimension to allow when applying gates. ``None`` means
+        no limit (the bonds can grow without bound), which is only tractable for
+        small or shallow circuits.
+    cutoff : float, optional
+        The singular value cutoff to use when compressing bonds after applying a
+        gate.
+    gauge_smudge : float, optional
+        A small value added to the gauges before they are multiplied in and
+        inverted, to avoid numerical issues with very small singular values.
+    renorm : bool, optional
+        Whether to renormalize the singular values of a bond after each gate,
+        before reinserting them into the gauges. The default ``True`` keeps the
+        state normalized, which is numerically stable for deep circuits of
+        non-near-identity gates (expectation values computed with
+        ``normalized=True`` are unaffected). Set to ``False`` to instead track
+        the norm of the state, e.g. for near-identity (time evolution) gates.
+    equilibrate_every : int, optional
+        If given, call :meth:`equilibrate` automatically after every this many
+        gates have been applied.
+    equilibrate_opts : dict, optional
+        Default options to supply to :meth:`equilibrate`, and thus
+        :meth:`~quimb.tensor.tnag.core.TensorNetworkGen.gauge_all_simple_`.
+    dtype : str, optional
+        The data type of the initial product state.
+    psi0 : TensorNetworkGenVector, optional
+        Supply the initial state directly instead of building a product state
+        from ``edges``. The geometry is then read from this state.
+
+    Attributes
+    ----------
+    edges : tuple[tuple[hashable, hashable]]
+        The unique edges defining the geometry.
+    sites : tuple[hashable]
+        The sites of the PEPS.
+    gauges : dict[str, array_like]
+        The simple update bond gauges, keyed by bond index.
+    psi : TensorNetworkGenVector
+        The current state, with the gauges absorbed.
+
+    See Also
+    --------
+    CircuitMPS, SimpleUpdateGen
+    """
+
+    def __init__(
+        self,
+        edges=None,
+        *,
+        gates=None,
+        max_bond=None,
+        cutoff=1e-10,
+        gauge_smudge=1e-6,
+        renorm=True,
+        equilibrate_every=None,
+        equilibrate_opts=None,
+        dtype="complex128",
+        psi0=None,
+        **circuit_opts,
+    ):
+        if psi0 is None:
+            if edges is None:
+                if gates is None:
+                    raise ValueError(
+                        "You must supply one of `edges`, `gates` or `psi0` to "
+                        "define the PEPS geometry."
+                    )
+                # infer geometry from the two site gates
+                edges = [
+                    g.qubits
+                    for g in map(parse_to_gate, gates)
+                    if len(g.qubits) == 2
+                ]
+            edges = tuple(gen_unique_edges(edges))
+            sites = tuple(sorted({s for e in edges for s in e}))
+            # |00...0> product state with size 1 bonds on the edges
+            psi0 = TN_from_sites_product_state(
+                {site: np.array([1.0, 0.0], dtype=dtype) for site in sites}
+            )
+            for cooa, coob in edges:
+                psi0[cooa].new_bond(psi0[coob])
+        else:
+            edges = tuple(gen_unique_edges(psi0.gen_bond_coos()))
+            sites = tuple(psi0.sites)
+
+        self.edges = edges
+        self.sites = sites
+        self._edge_set = {frozenset(e) for e in edges}
+        self._site_set = set(sites)
+
+        # simple update gate / gauge options
+        self._su_opts = {
+            "max_bond": max_bond,
+            "cutoff": cutoff,
+            "smudge": gauge_smudge,
+            "renorm": renorm,
+        }
+        self._equilibrate_every = equilibrate_every
+        self._equilibrate_opts = ensure_dict(equilibrate_opts)
+
+        # don't tag gates - not needed for simple update
+        circuit_opts.setdefault("tag_gate_numbers", False)
+        circuit_opts.setdefault("tag_gate_rounds", False)
+        circuit_opts.setdefault("tag_gate_labels", False)
+
+        super().__init__(psi0=psi0, **circuit_opts)
+
+        # set up the simple update bond gauges
+        self._gauges = {}
+        self._psi.gauge_all_simple_(gauges=self._gauges, max_iterations=1)
+
+    def copy(self):
+        """Copy the circuit, its state and gauges."""
+        new = super().copy()
+        new.edges = self.edges
+        new.sites = self.sites
+        new._edge_set = self._edge_set
+        new._site_set = self._site_set
+        new._su_opts = dict(self._su_opts)
+        new._equilibrate_every = self._equilibrate_every
+        new._equilibrate_opts = dict(self._equilibrate_opts)
+        new._gauges = dict(self._gauges)
+        return new
+
+    @property
+    def gauges(self):
+        """A copy of the current simple update bond gauges."""
+        return dict(self._gauges)
+
+    def _apply_gate(self, gate, tags=None, **gate_opts):
+        if gate.controls:
+            raise NotImplementedError(
+                "Controlled gates are not supported by "
+                "`CircuitPEPSSimpleUpdate`."
+            )
+        if gate.special:
+            raise NotImplementedError(
+                f"The special gate {gate.label!r} is not supported by "
+                "`CircuitPEPSSimpleUpdate`, supply it as a raw array instead."
+            )
+
+        where = gate.qubits
+
+        if len(where) > 2:
+            raise ValueError(
+                "`CircuitPEPSSimpleUpdate` only supports one and two site "
+                f"gates, but got {len(where)} sites: {where}."
+            )
+        if (len(where) == 2) and (frozenset(where) not in self._edge_set):
+            raise ValueError(
+                f"The gate acts on sites {where} which are not a declared "
+                "edge of the PEPS - only nearest neighbor gates are allowed."
+            )
+
+        opts = {**self._su_opts, **gate_opts}
+        self._psi.gate_simple_(gate.array, where, gauges=self._gauges, **opts)
+
+        self._gates.append(gate)
+
+        if self._equilibrate_every and (
+            len(self._gates) % self._equilibrate_every == 0
+        ):
+            self.equilibrate()
+
+    def equilibrate(self, **kwargs):
+        """Re-equilibrate the bond gauges with the current state, i.e. iterate
+        the simple update gauging to self consistency (like evolving with a zero
+        time step). This can improve the accuracy of subsequent gates and
+        expectation values.
+
+        Parameters
+        ----------
+        kwargs
+            Supplied to
+            :meth:`~quimb.tensor.tnag.core.TensorNetworkGen.gauge_all_simple_`,
+            overriding any defaults in ``equilibrate_opts``.
+        """
+        opts = {**self._equilibrate_opts, **kwargs}
+        self._psi.gauge_all_simple_(gauges=self._gauges, **opts)
+
+    def get_state(self, absorb_gauges=True):
+        """Return the current state, optionally absorbing the gauges.
+
+        Parameters
+        ----------
+        absorb_gauges : bool, optional
+            If ``True`` (default), return a plain PEPS with the gauges absorbed
+            into the tensors. If ``False``, the gauges are left as separate,
+            uncontracted tensors on the bonds.
+
+        Returns
+        -------
+        TensorNetworkGenVector
+        """
+        psi = self._psi.copy()
+        if absorb_gauges:
+            psi.gauge_simple_insert(self._gauges)
+        else:
+            for ix, g in self._gauges.items():
+                psi |= Tensor(g, inds=[ix])
+        if not self.convert_eager:
+            self._maybe_convert(psi)
+        return psi
+
+    @property
+    def psi(self):
+        return self.get_state(absorb_gauges=True)
+
+    @property
+    def psi_gauged(self):
+        """The raw internal PEPS, in Vidal-like gauge: the simple update bond
+        gauges are stored separately (in :attr:`gauges`) and *not* absorbed.
+        Use :attr:`psi` to get the state with the gauges absorbed back in.
+        """
+        return self._psi.copy()
+
+    def local_expectation(
+        self,
+        G,
+        where,
+        *,
+        normalized=True,
+        max_distance=1,
+        **contract_opts,
+    ):
+        """Compute the local expectation value of operator ``G`` at ``where``,
+        using the simple update gauges and a cluster approximation of the
+        environment.
+
+        Parameters
+        ----------
+        G : array_like
+            The local operator to compute the expectation of.
+        where : hashable or sequence[hashable]
+            The site or sites the operator acts on.
+        normalized : bool, optional
+            Whether to normalize the expectation value by the local norm.
+        max_distance : int, optional
+            How many neighboring shells of tensors to include in the cluster
+            environment beyond the operator's sites. Larger is more accurate but
+            more expensive.
+        contract_opts
+            Supplied to
+            :meth:`~quimb.tensor.tnag.core.TensorNetworkGenVector.compute_local_expectation_cluster`.
+
+        Returns
+        -------
+        float
+        """
+        if where in self._site_set:
+            where = (where,)
+        else:
+            where = tuple(where)
+
+        return self._psi.compute_local_expectation_cluster(
+            {where: G},
+            gauges=self._gauges,
+            normalized=normalized,
+            max_distance=max_distance,
+            **contract_opts,
+        )
+
+    @property
+    def uni(self):
+        raise ValueError(
+            "You can't extract the circuit unitary TN from a "
+            "``CircuitPEPSSimpleUpdate``."
+        )
+
+    def _unsupported_exact(self, *_, **__):
+        raise NotImplementedError(
+            f"{type(self).__name__!r} represents the state as an approximate, "
+            "compressed PEPS, so methods that require exactly contracting the "
+            "full state are not supported. Use `local_expectation` (which uses "
+            "the cluster approximation) or work with the `psi` tensor network "
+            "directly instead."
+        )
+
+    # exact-contraction methods would silently be intractable / wrong for a
+    # large PEPS, so explicitly disable them rather than return bad values
+    to_dense = _unsupported_exact
+    amplitude = _unsupported_exact
+    partial_trace = _unsupported_exact
+    sample = _unsupported_exact
+    sample_chaotic = _unsupported_exact
+    sample_chaotic_rehearse = _unsupported_exact
+
+    def calc_qubit_ordering(self, qubits=None):
+        """A PEPS has no inherent linear ordering; just return the sites."""
+        if qubits is None:
+            return tuple(self.sites)
+        return tuple(qubits)
+
+    def get_psi_reverse_lightcone(self, where, keep_psi0=False):
+        """The reverse lightcone is not meaningful for a PEPS simple update
+        state, so just return the full state.
         """
         return self.psi

--- a/tests/test_tensor/test_circuit_peps_su.py
+++ b/tests/test_tensor/test_circuit_peps_su.py
@@ -1,0 +1,191 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import quimb as qu
+import quimb.tensor as qtn
+
+
+def rand_circuit_gates(sites, edges, n_layers=2, seed=0):
+    """Generate a fixed sequence of gates in quimb's ``(array, *qubits)``
+    format: each layer is a round of single site gates followed by a round of
+    two site gates on the edges.
+    """
+    rng = np.random.default_rng(seed)
+    gates = []
+    for _ in range(n_layers):
+        for s in sites:
+            gates.append((qu.rand_uni(2, seed=int(rng.integers(1 << 30))), s))
+        for a, b in edges:
+            gates.append(
+                (qu.rand_uni(4, seed=int(rng.integers(1 << 30))), a, b)
+            )
+    return gates
+
+
+def test_chain_matches_mps_exactly():
+    # a 1D chain is a tree, so simple update (with equilibrated gauges) is
+    # exact and must agree with an (exact) MPS circuit simulation
+    n = 6
+    edges = [(i, i + 1) for i in range(n - 1)]
+    gates = rand_circuit_gates(range(n), edges, n_layers=2, seed=42)
+
+    cmps = qtn.CircuitMPS(N=n, max_bond=64, cutoff=0.0)
+    csu = qtn.CircuitPEPSSimpleUpdate(edges, max_bond=64, cutoff=1e-14)
+    cmps.apply_gates(gates)
+    csu.apply_gates(gates)
+
+    # restore exact canonical form before measuring
+    csu.equilibrate(max_iterations=500, tol=1e-13)
+
+    for i in range(n):
+        ref = cmps.local_expectation(qu.pauli("Z"), i, normalized=True)
+        val = csu.local_expectation(qu.pauli("Z"), i, max_distance=0)
+        assert_allclose(complex(val), complex(ref), atol=1e-10)
+
+
+def test_psi_is_a_peps_and_truncates_bond():
+    edges = qtn.edges_2d_square(3, 3)
+    max_bond = 4
+    csu = qtn.CircuitPEPSSimpleUpdate(edges, max_bond=max_bond)
+    csu.apply_gates(
+        rand_circuit_gates(csu.sites, csu.edges, n_layers=3, seed=1)
+    )
+
+    psi = csu.psi
+    assert isinstance(psi, qtn.TensorNetworkGenVector)
+    assert psi.num_tensors == len(csu.sites)
+    assert psi.max_bond() <= max_bond
+
+
+def test_non_edge_and_too_many_sites_raise():
+    edges = qtn.edges_2d_square(2, 2)
+    csu = qtn.CircuitPEPSSimpleUpdate(edges, max_bond=8)
+
+    # (0, 0) and (1, 1) are diagonal, not a declared edge
+    with pytest.raises(ValueError):
+        csu.apply_gate(qu.rand_uni(4), (0, 0), (1, 1))
+
+    # three site gates are not supported
+    with pytest.raises(ValueError):
+        csu.apply_gate(qu.rand_uni(8), (0, 0), (0, 1), (1, 0))
+
+
+def test_geometry_inferred_from_gates():
+    gates = [
+        (qu.rand_uni(2), 0),
+        (qu.rand_uni(4), 0, 1),
+        (qu.rand_uni(4), 1, 2),
+    ]
+    csu = qtn.CircuitPEPSSimpleUpdate(gates=gates, max_bond=8)
+    assert set(csu.sites) == {0, 1, 2}
+    assert set(csu.edges) == {(0, 1), (1, 2)}
+    # the inferred geometry should accept all the gates
+    csu.apply_gates(gates)
+
+
+def test_copy_is_independent():
+    edges = qtn.edges_2d_square(2, 2)
+    csu = qtn.CircuitPEPSSimpleUpdate(edges, max_bond=8)
+    csu.apply_gates(rand_circuit_gates(csu.sites, csu.edges, seed=3))
+
+    other = csu.copy()
+    n_before = csu.num_gates
+    other.apply_gate(qu.rand_uni(4), (0, 0), (0, 1))
+
+    # mutating the copy must not affect the original
+    assert csu.num_gates == n_before
+    assert other.num_gates == n_before + 1
+    assert csu.gauges is not other.gauges
+
+
+def test_psi0_supplied_directly():
+    edges = qtn.edges_2d_square(2, 2)
+    csu = qtn.CircuitPEPSSimpleUpdate(edges, max_bond=8)
+    csu.apply_gates(rand_circuit_gates(csu.sites, csu.edges, seed=5))
+    psi0 = csu.psi
+
+    # rebuild a circuit from an existing PEPS and check the geometry matches
+    csu2 = qtn.CircuitPEPSSimpleUpdate(psi0=psi0, max_bond=8)
+    assert set(csu2.sites) == set(csu.sites)
+    assert set(csu2.edges) == set(csu.edges)
+
+
+def test_loopy_plaquette_matches_exact():
+    # on a 2x2 plaquette (a loop) simple update is approximate, but with a
+    # full-system cluster (max_distance covering all sites) and no bond
+    # truncation it must reproduce the exact result
+    edges = qtn.edges_2d_square(2, 2)
+    sites = sorted({s for e in edges for s in e})
+    gates = rand_circuit_gates(sites, edges, n_layers=1, seed=7)
+
+    # exact reference via a dense circuit on integer qubits
+    qmap = {s: i for i, s in enumerate(sites)}
+    ref = qtn.Circuit(N=len(sites))
+    for G, *where in gates:
+        ref.apply_gate(G, *(qmap[s] for s in where))
+
+    csu = qtn.CircuitPEPSSimpleUpdate(edges, max_bond=16)
+    csu.apply_gates(gates)
+    csu.equilibrate(max_iterations=300, tol=1e-12)
+
+    for s in sites:
+        exact = complex(ref.local_expectation(qu.pauli("Z"), qmap[s]))
+        val = csu.local_expectation(qu.pauli("Z"), s, max_distance=2)
+        assert_allclose(complex(val), exact, atol=1e-10)
+
+
+def test_loopy_cluster_converges_to_exact():
+    # the cluster expectation error should (roughly) decrease as max_distance
+    # grows, on a loopy lattice with an essentially exact (large max_bond) state
+    edges = qtn.edges_2d_square(3, 3)
+    sites = sorted({s for e in edges for s in e})
+    gates = rand_circuit_gates(sites, edges, n_layers=2, seed=11)
+
+    qmap = {s: i for i, s in enumerate(sites)}
+    ref = qtn.Circuit(N=len(sites))
+    for G, *where in gates:
+        ref.apply_gate(G, *(qmap[s] for s in where))
+    exact = {
+        s: complex(ref.local_expectation(qu.pauli("Z"), qmap[s]))
+        for s in sites
+    }
+
+    csu = qtn.CircuitPEPSSimpleUpdate(edges, max_bond=16)
+    csu.apply_gates(gates)
+    csu.equilibrate(max_iterations=200, tol=1e-10)
+
+    def err(md):
+        return max(
+            abs(
+                csu.local_expectation(qu.pauli("Z"), s, max_distance=md)
+                - exact[s]
+            )
+            for s in sites
+        )
+
+    # the largest cluster must be much more accurate than the smallest
+    assert err(3) < err(0) / 5
+
+
+def test_psi_gauged_keeps_gauges_separate():
+    edges = qtn.edges_2d_square(3, 3)
+    csu = qtn.CircuitPEPSSimpleUpdate(edges, max_bond=8)
+    csu.apply_gates(rand_circuit_gates(csu.sites, csu.edges, seed=2))
+
+    # psi has gauges absorbed, psi_gauged does not - they are different TNs but
+    # represent the same physical state up to the (separate) gauges
+    assert csu.psi_gauged.num_tensors == len(csu.sites)
+    assert len(csu.gauges) == len(csu.edges)
+
+
+def test_unsupported_exact_methods_raise():
+    edges = qtn.edges_2d_square(3, 3)
+    csu = qtn.CircuitPEPSSimpleUpdate(edges, max_bond=8)
+    csu.apply_gates(rand_circuit_gates(csu.sites, csu.edges, seed=4))
+
+    for method in ("to_dense", "amplitude", "sample"):
+        with pytest.raises(NotImplementedError):
+            getattr(csu, method)()
+    with pytest.raises(ValueError):
+        csu.uni


### PR DESCRIPTION
This PR adds `CircuitPEPSSimpleUpdate` from #358 -- a circuit simulator that
keeps the state as a PEPS and applies gates using simple-update gauging.

The idea is simple: you give it the lattice (a list of `edges`), it starts in
|0…0⟩, and then you just throw gates at it like any other circuit. Under the
hood each two-qubit gate gets applied and the bond trimmed back to `max_bond`,
so it stays cheap even on big 2D lattices where you could never write out the
full state.

```python
circ = qtn.CircuitPEPSSimpleUpdate(edges, max_bond=16)
circ.apply_gates(gates)
peps = circ.psi
mz = circ.local_expectation(qu.pauli("Z"), site)
```
A few things worth mentioning:

- Geometry can come from edges, be inferred from the gates, or from an existing psi0.
- Only single- and nearest-neighbor (on-edge) gates are allowed, anything else raises a clear error.
- equilibrate() re-gauges the bonds, psi gives the gauged state back, and local_expectation uses the cluster approximation.
- I made the exact-only methods (to_dense, sample, amplitude, …) raise instead of silently trying to contract a giant PEPS and giving junk.
- I built it as a Circuit subclass, same as CircuitMPS, but if you'd rather
- it be a leaner standalone class, happy to switch.

Does it actually work? Tests are in test_circuit_peps_su.py. The nice
checks: on a chain (a tree, so SU is exact) it matches an exact MPS to ~1e-12,
and on a loopy 2×2 with a full cluster it matches exact to ~1e-15. It also
happily runs a 144-qubit / 1200-gate circuit in ~1s, which is the whole point.

---

<img width="1324" height="195" alt="image" src="https://github.com/user-attachments/assets/05823422-fb4c-41ea-8e97-99348762f69e" />

--
## AI Disclosure:

I used Claude (via Claude Code) to help inspect the repository patterns, compare the implementation against the issue requirements, draft the class and tests, and run local verification, including debugging the tricky bits like the simple update gauging and the renorm stability fix. I manually reviewed the code, snapshots, design tradeoffs, and command outputs, and checked it against exact simulations to make sure it's correct before preparing this PR. Happy to change anything you'd like.
