### PR TITLE
Add CircuitMPSLazy for lazy nonlocal MPS circuit simulation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ Release notes for `quimb`.
 
 **Enhancements:**
 
+- add [`CircuitMPSLazy`](quimb.tensor.circuit.CircuitMPSLazy): an MPS circuit simulator that applies nonlocal gates lazily as MPO fragments before flushing back through the existing 1D compression methods.
 - [`TensorNetwork.gauge_all_simple`](quimb.tensor.tensor_core.TensorNetwork.gauge_all_simple): add a ``fuse_multibonds`` option for updating gauges while preserving multi-index bonds, supported by explicit bond-index selection in [`tensor_compress_bond`](quimb.tensor.tensor_core.tensor_compress_bond).
 - add [`LatticeBondMap`](quimb.tensor.tnag.core.LatticeBondMap): helper for consistently assigning lattice bond indices across ordinary and periodic boundaries, use it in PEPS, PEPO, PEPS3D, scalar 2D/3D lattice tensor-network construction, and classical Ising tensor-network construction.
 - [`eigh_truncated`](quimb.tensor.decomp.eigh_truncated): add a ``shift`` option for optional diagonal regularization.

--- a/quimb/tensor/__init__.py
+++ b/quimb/tensor/__init__.py
@@ -4,6 +4,7 @@ from .circuit import (
     Circuit,
     CircuitDense,
     CircuitMPS,
+    CircuitMPSLazy,
     CircuitPermMPS,
     Gate,
 )
@@ -241,6 +242,7 @@ __all__ = (
     "Circuit",
     "CircuitDense",
     "CircuitMPS",
+    "CircuitMPSLazy",
     "CircuitPermMPS",
     "cnf_file_parse",
     "connect",

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -4969,6 +4969,12 @@ def _lazy_mps_gate_span(gate):
     return where, set(range(min(where), max(where) + 1))
 
 
+def _lazy_mps_gate_is_nonlocal(gate):
+    """Whether a gate skips over intermediate sites in the current ordering."""
+    where, gate_span = _lazy_mps_gate_span(gate)
+    return len(gate_span) > len(where)
+
+
 def _lazy_mps_convert_gate(circ, G):
     """Convert and cache a dense gate array if eager backend conversion is
     enabled for this circuit.
@@ -4981,11 +4987,127 @@ def _lazy_mps_convert_gate(circ, G):
     return G
 
 
-def _lazy_mps_should_flush(circ, gate_span):
+def _lazy_mps_should_flush(circ, gate_sites, gate_span):
     """Decide whether a new gate should trigger a flush of pending lazy
     structure before it is stacked.
     """
-    return not circ._pending_sites.isdisjoint(gate_span)
+    if not circ._pending_gate_sites.isdisjoint(gate_sites):
+        return True
+
+    # Allow a small amount of span-sharing for zipup, but don't let disjoint
+    # long-range gates accumulate into a near-full-chain window.
+    return (
+        circ._compress_method == "zipup"
+        and circ._pending_lazy_gate_count >= 2
+        and not circ._pending_sites.isdisjoint(gate_span)
+    )
+
+
+def _lazy_mps_overlap_sites(circ, where, gate_span):
+    """Return the site set used to detect lazy overlap for this method."""
+    if circ._compress_method == "zipup":
+        return set(where)
+    return gate_span
+
+
+def _lazy_mps_should_force_eager(circ, gate_sites):
+    """Whether a nonlocal gate should bypass lazy stacking and use the eager
+    path based on the recent overlap pattern.
+    """
+    return (
+        circ._force_eager_nonlocal_sites is not None
+        and not circ._force_eager_nonlocal_sites.isdisjoint(gate_sites)
+    )
+
+
+def _lazy_mps_would_span_full_chain(circ, gate_span):
+    """Whether stacking ``gate_span`` would expand the pending lazy support to
+    cover the entire chain.
+    """
+    if not circ._pending_sites:
+        return False
+
+    pending_min = min(circ._pending_sites)
+    pending_max = max(circ._pending_sites)
+    gate_min = min(gate_span)
+    gate_max = max(gate_span)
+    return (min(pending_min, gate_min) == 0) and (
+        max(pending_max, gate_max) == circ.N - 1
+    )
+
+
+def _lazy_mps_window(circ):
+    """Return the minimal contiguous window covering the pending lazy support."""
+    if not circ._pending_sites:
+        return None
+
+    a = min(circ._pending_sites)
+    b = max(circ._pending_sites)
+    return a, b
+
+
+def _lazy_mps_uses_window_flush(circ):
+    """Whether the compression method supports local subwindow flushing."""
+    return circ._compress_method in {"dm", "zipup"}
+
+
+def _lazy_mps_window_flush(circ):
+    """Attempt to flush only the local window touched by pending lazy support.
+
+    Returns
+    -------
+    bool
+        Whether a local windowed flush was performed.
+    """
+    if not _lazy_mps_uses_window_flush(circ):
+        return False
+
+    window = _lazy_mps_window(circ)
+    if window is None:
+        return False
+
+    wa, wb = window
+    if wa == wb:
+        return False
+    if (wa == 0) and (wb == circ.N - 1):
+        return False
+
+    from .tn1d.compress import tensor_network_1d_compress
+
+    site_tags = [circ._psi.site_tag(i) for i in range(wa, wb + 1)]
+    _, subpsi = circ._psi.partition(site_tags, which="any", inplace=True)
+
+    kwargs = dict(circ._compress_opts)
+    kwargs.setdefault("check_1d", False)
+
+    tensor_network_1d_compress(
+        subpsi,
+        max_bond=circ.gate_opts.get("max_bond"),
+        cutoff=circ.gate_opts.get("cutoff", 1e-10),
+        method=circ._compress_method,
+        site_tags=site_tags,
+        permute_arrays=False,
+        inplace=True,
+        **kwargs,
+    )
+
+    circ._psi |= subpsi
+    return True
+
+
+def _lazy_mps_reset_pending_state(circ):
+    """Clear bookkeeping for any pending lazy gate structure."""
+    circ.gate_opts["info"]["cur_orthog"] = None
+    circ._pending = False
+    circ._pending_lazy_gate_count = 0
+    circ._force_eager_nonlocal_sites = None
+    circ._pending_gate_sites.clear()
+    circ._pending_sites.clear()
+
+
+def _lazy_mps_apply_eager(circ, gate, lazy_tags, **gate_opts):
+    """Apply ``gate`` directly through the eager ``CircuitMPS`` path."""
+    CircuitMPS._apply_gate(circ, gate, tags=lazy_tags, **gate_opts)
 
 
 def _lazy_mps_flush(circ):
@@ -4995,10 +5117,14 @@ def _lazy_mps_flush(circ):
     if not circ._pending:
         return
 
+    if _lazy_mps_window_flush(circ):
+        _lazy_mps_reset_pending_state(circ)
+        return
+
     from .tn1d.compress import tensor_network_1d_compress
 
     kwargs = dict(circ._compress_opts)
-    if circ._compress_method in {"dm", "zipup"}:
+    if _lazy_mps_uses_window_flush(circ):
         kwargs.setdefault("check_1d", False)
     info = None
     if circ._compress_method.startswith("fit"):
@@ -5016,9 +5142,7 @@ def _lazy_mps_flush(circ):
         **kwargs,
     )
     circ._last_compress_info = None if info is None else dict(info)
-    circ.gate_opts["info"]["cur_orthog"] = None
-    circ._pending = False
-    circ._pending_sites.clear()
+    _lazy_mps_reset_pending_state(circ)
 
 
 def _lazy_mps_stack_gate(circ, gate, tags=None, info=None):
@@ -5028,12 +5152,17 @@ def _lazy_mps_stack_gate(circ, gate, tags=None, info=None):
     where, gate_span = _lazy_mps_gate_span(gate)
     G = _lazy_mps_convert_gate(circ, gate.array)
 
-    mpo = MatrixProductOperator.from_dense(
-        G,
-        dims=tuple(circ._psi.phys_dim(i) for i in where),
-        sites=where,
-        L=circ.N,
-    )
+    mpo_key = (id(G), where)
+    mpo = circ._lazy_mpo_cache.get(mpo_key)
+    if mpo is None:
+        mpo = MatrixProductOperator.from_dense(
+            G,
+            dims=tuple(circ._psi.phys_dim(i) for i in where),
+            sites=where,
+            L=circ.N,
+        )
+        circ._lazy_mpo_cache[mpo_key] = mpo
+    mpo = mpo.copy()
     for tag in _lazy_mps_gate_tags(circ, gate, tags=tags):
         mpo.add_tag(tag)
 
@@ -5045,6 +5174,13 @@ def _lazy_mps_stack_gate(circ, gate, tags=None, info=None):
         info=info,
     )
     circ._pending = True
+    circ._pending_lazy_gate_count += 1
+    if circ._pending_lazy_gate_count > 1:
+        circ._single_gate_lazy_flush_streak = 0
+    circ._force_eager_nonlocal_sites = None
+    circ._pending_gate_sites |= _lazy_mps_overlap_sites(
+        circ, where, gate_span
+    )
     circ._pending_sites |= gate_span
 
 
@@ -5077,7 +5213,12 @@ class CircuitMPSLazy(CircuitMPS):
         self._compress_method = method
         self._compress_opts = ensure_dict(compress_opts)
         self._last_compress_info = None
+        self._lazy_mpo_cache = {}
         self._pending = False
+        self._pending_lazy_gate_count = 0
+        self._single_gate_lazy_flush_streak = 0
+        self._force_eager_nonlocal_sites = None
+        self._pending_gate_sites = set()
         self._pending_sites = set()
         super().__init__(
             N=N,
@@ -5097,24 +5238,62 @@ class CircuitMPSLazy(CircuitMPS):
         """
         _lazy_mps_flush(self)
 
+    def _flush_for_access(self):
+        """Materialize pending lazy structure before state access."""
+        self._compress()
+        self._force_eager_nonlocal_sites = None
+
     def _apply_gate(self, gate, tags=None, **gate_opts):
         """Apply a gate using lazy stacking for ordinary gates and the eager
         ``CircuitMPS`` path for controlled / special cases.
         """
         opts = {**self.gate_opts, **gate_opts}
+        lazy_tags = _lazy_mps_gate_tags(self, gate, tags=tags)
 
         if gate.special or gate.controls:
             self._compress()
-            super()._apply_gate(
-                gate,
-                tags=_lazy_mps_gate_tags(self, gate, tags=tags),
-                **gate_opts,
-            )
+            _lazy_mps_apply_eager(self, gate, lazy_tags, **gate_opts)
             return
 
-        _, gate_span = _lazy_mps_gate_span(gate)
-        if _lazy_mps_should_flush(self, gate_span):
+        if not _lazy_mps_gate_is_nonlocal(gate):
+            if self._pending:
+                self._compress()
+            _lazy_mps_apply_eager(self, gate, lazy_tags, **gate_opts)
+            return
+
+        where, gate_span = _lazy_mps_gate_span(gate)
+        gate_sites = set(where)
+        if _lazy_mps_should_force_eager(self, gate_sites):
+            _lazy_mps_apply_eager(self, gate, lazy_tags, **gate_opts)
+            self._force_eager_nonlocal_sites |= gate_sites
+            return
+
+        flush_sites = _lazy_mps_overlap_sites(self, where, gate_span)
+
+        if (
+            self._compress_method == "zipup"
+            and _lazy_mps_would_span_full_chain(self, gate_span)
+        ):
             self._compress()
+
+        if _lazy_mps_should_flush(self, flush_sites, gate_span):
+            if self._pending_lazy_gate_count == 1:
+                self._single_gate_lazy_flush_streak += 1
+            else:
+                self._single_gate_lazy_flush_streak = 0
+            self._compress()
+            if (
+                self._single_gate_lazy_flush_streak >= 2
+                and self._compress_method == "zipup"
+            ):
+                self._force_eager_nonlocal_sites = set(gate_sites)
+                _lazy_mps_apply_eager(
+                    self,
+                    gate,
+                    lazy_tags,
+                    **gate_opts,
+                )
+                return
 
         _lazy_mps_stack_gate(
             self,
@@ -5143,28 +5322,28 @@ class CircuitMPSLazy(CircuitMPS):
         """Return the current state as a proper MPS, flushing pending lazy
         structure first if needed.
         """
-        self._compress()
+        self._flush_for_access()
         return super().psi
 
     def sample(self, C, *args, **kwargs):
         """Sample from the current state after materializing any pending lazy
         gates into the MPS.
         """
-        self._compress()
+        self._flush_for_access()
         yield from super().sample(C, *args, **kwargs)
 
     def local_expectation(self, G, where, *args, **kwargs):
         """Compute a local expectation value after flushing pending lazy
         structure into the MPS.
         """
-        self._compress()
+        self._flush_for_access()
         return super().local_expectation(G, where, *args, **kwargs)
 
     def fidelity_estimate(self):
         """Estimate fidelity using the compressed MPS after any pending lazy
         gates have been flushed.
         """
-        self._compress()
+        self._flush_for_access()
         return super().fidelity_estimate()
 
     @property

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -4991,14 +4991,14 @@ def _lazy_mps_should_flush(circ, gate_sites, gate_span):
     """Decide whether a new gate should trigger a flush of pending lazy
     structure before it is stacked.
     """
-    if not circ._pending_gate_sites.isdisjoint(gate_sites):
+    if _lazy_mps_has_gate_overlap(circ, gate_sites):
         return True
 
-    # Allow a small amount of span-sharing for zipup, but don't let disjoint
-    # long-range gates accumulate into a near-full-chain window.
+    # Allow one layer of span-sharing for zipup, but don't let disjoint
+    # long-range gates keep expanding the pending window unchecked.
     return (
         circ._compress_method == "zipup"
-        and circ._pending_lazy_gate_count >= 2
+        and circ._pending_lazy_gate_count >= 1
         and not circ._pending_sites.isdisjoint(gate_span)
     )
 
@@ -5008,6 +5008,11 @@ def _lazy_mps_overlap_sites(circ, where, gate_span):
     if circ._compress_method == "zipup":
         return set(where)
     return gate_span
+
+
+def _lazy_mps_has_gate_overlap(circ, gate_sites):
+    """Whether pending lazy structure overlaps directly on gate sites."""
+    return not circ._pending_gate_sites.isdisjoint(gate_sites)
 
 
 def _lazy_mps_should_force_eager(circ, gate_sites):
@@ -5277,7 +5282,10 @@ class CircuitMPSLazy(CircuitMPS):
             self._compress()
 
         if _lazy_mps_should_flush(self, flush_sites, gate_span):
-            if self._pending_lazy_gate_count == 1:
+            if (
+                self._pending_lazy_gate_count == 1
+                and _lazy_mps_has_gate_overlap(self, gate_sites)
+            ):
                 self._single_gate_lazy_flush_streak += 1
             else:
                 self._single_gate_lazy_flush_streak = 0

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -4945,6 +4945,234 @@ class CircuitMPS(Circuit):
         )
 
 
+def _lazy_mps_gate_tags(circ, gate, tags=None):
+    """Build the full tag set for a lazily stacked gate using the same
+    numbering / round / label conventions as ``Circuit._apply_gate``.
+    """
+    tags = tags_to_oset(tags)
+    if circ.tag_gate_numbers:
+        tags.add(circ.gate_tag(circ.num_gates))
+    if circ.tag_gate_rounds and (gate.round is not None):
+        tags.add(circ.round_tag(gate.round))
+    if circ.tag_gate_labels and (gate.tag is not None):
+        tags.add(gate.tag)
+    return tags
+
+
+def _lazy_mps_gate_span(gate):
+    """Return both the acted-on sites and the contiguous support they span.
+
+    The span is used to decide when a pending lazy batch must be flushed
+    before stacking another gate.
+    """
+    where = tuple(gate.qubits)
+    return where, set(range(min(where), max(where) + 1))
+
+
+def _lazy_mps_convert_gate(circ, G):
+    """Convert and cache a dense gate array if eager backend conversion is
+    enabled for this circuit.
+    """
+    if circ.convert_eager:
+        key = id(G)
+        if key not in circ._backend_gate_cache:
+            circ._backend_gate_cache[key] = circ._maybe_convert(G)
+        return circ._backend_gate_cache[key]
+    return G
+
+
+def _lazy_mps_should_flush(circ, gate_span):
+    """Decide whether a new gate should trigger a flush of pending lazy
+    structure before it is stacked.
+    """
+    return not circ._pending_sites.isdisjoint(gate_span)
+
+
+def _lazy_mps_flush(circ):
+    """Compress the accumulated 1D-like tensor network back into a proper MPS
+    and reset the lazy bookkeeping.
+    """
+    if not circ._pending:
+        return
+
+    from .tn1d.compress import tensor_network_1d_compress
+
+    kwargs = dict(circ._compress_opts)
+    info = None
+    if circ._compress_method.startswith("fit"):
+        info = kwargs.get("info")
+        if info is None:
+            info = {}
+            kwargs["info"] = info
+
+    circ._psi = tensor_network_1d_compress(
+        circ._psi,
+        max_bond=circ.gate_opts.get("max_bond"),
+        cutoff=circ.gate_opts.get("cutoff", 1e-10),
+        method=circ._compress_method,
+        inplace=True,
+        **kwargs,
+    )
+    circ._last_compress_info = None if info is None else dict(info)
+    circ.gate_opts["info"]["cur_orthog"] = None
+    circ._pending = False
+    circ._pending_sites.clear()
+
+
+def _lazy_mps_stack_gate(circ, gate, tags=None, info=None):
+    """Turn a dense gate into a supported sub-MPO and stack it onto the
+    current MPS lazily, without contracting or compressing yet.
+    """
+    where, gate_span = _lazy_mps_gate_span(gate)
+    G = _lazy_mps_convert_gate(circ, gate.array)
+
+    mpo = MatrixProductOperator.from_dense(
+        G,
+        dims=tuple(circ._psi.phys_dim(i) for i in where),
+        sites=where,
+        L=circ.N,
+    )
+    for tag in _lazy_mps_gate_tags(circ, gate, tags=tags):
+        mpo.add_tag(tag)
+
+    circ._psi.gate_with_submpo_(
+        mpo,
+        where=where,
+        method="lazy",
+        inplace_mpo=True,
+        info=info,
+    )
+    circ._pending = True
+    circ._pending_sites |= gate_span
+
+
+class CircuitMPSLazy(CircuitMPS):
+    """Quantum circuit simulation that stacks gates lazily as sub-MPOs and
+    only periodically compresses the accumulated network back into a true MPS
+    using :func:`quimb.tensor.tn1d.compress.tensor_network_1d_compress`.
+
+    Ordinary gates are buffered as non-overlapping lazy layers when possible.
+    Accessors such as :attr:`psi`, :meth:`sample`, and
+    :meth:`local_expectation` first flush the pending structure so callers
+    always observe a genuine MPS.
+    """
+
+    def __init__(
+        self,
+        N=None,
+        *,
+        psi0=None,
+        max_bond=None,
+        cutoff=1e-10,
+        method="dm",
+        compress_opts=None,
+        gate_opts=None,
+        dtype=None,
+        to_backend=None,
+        convert_eager=True,
+        **circuit_opts,
+    ):
+        self._compress_method = method
+        self._compress_opts = ensure_dict(compress_opts)
+        self._last_compress_info = None
+        self._pending = False
+        self._pending_sites = set()
+        super().__init__(
+            N=N,
+            psi0=psi0,
+            max_bond=max_bond,
+            cutoff=cutoff,
+            gate_opts=gate_opts,
+            dtype=dtype,
+            to_backend=to_backend,
+            convert_eager=convert_eager,
+            **circuit_opts,
+        )
+
+    def _compress(self):
+        """Flush any pending lazy gates through the configured 1D compression
+        backend.
+        """
+        _lazy_mps_flush(self)
+
+    def _apply_gate(self, gate, tags=None, **gate_opts):
+        """Apply a gate using lazy stacking for ordinary gates and the eager
+        ``CircuitMPS`` path for controlled / special cases.
+        """
+        opts = {**self.gate_opts, **gate_opts}
+
+        if gate.special or gate.controls:
+            self._compress()
+            super()._apply_gate(
+                gate,
+                tags=_lazy_mps_gate_tags(self, gate, tags=tags),
+                **gate_opts,
+            )
+            return
+
+        _, gate_span = _lazy_mps_gate_span(gate)
+        if _lazy_mps_should_flush(self, gate_span):
+            self._compress()
+
+        _lazy_mps_stack_gate(
+            self,
+            gate,
+            tags=tags,
+            info=opts.get("info"),
+        )
+        self._gates.append(gate)
+
+    def apply_gates(self, gates, progbar=False, **gate_opts):
+        """Apply a sequence of gates while preserving the lazy batching
+        behavior of :meth:`_apply_gate`.
+        """
+        if progbar:
+            from ..utils import progbar as _progbar
+
+            gates = tuple(gates)
+            gates = _progbar(gates, total=len(gates))
+
+        for gate in gates:
+            gate = parse_to_gate(gate)
+            self._apply_gate(gate, **gate_opts)
+
+    @property
+    def psi(self):
+        """Return the current state as a proper MPS, flushing pending lazy
+        structure first if needed.
+        """
+        self._compress()
+        return super().psi
+
+    def sample(self, C, *args, **kwargs):
+        """Sample from the current state after materializing any pending lazy
+        gates into the MPS.
+        """
+        self._compress()
+        yield from super().sample(C, *args, **kwargs)
+
+    def local_expectation(self, G, where, *args, **kwargs):
+        """Compute a local expectation value after flushing pending lazy
+        structure into the MPS.
+        """
+        self._compress()
+        return super().local_expectation(G, where, *args, **kwargs)
+
+    def fidelity_estimate(self):
+        """Estimate fidelity using the compressed MPS after any pending lazy
+        gates have been flushed.
+        """
+        self._compress()
+        return super().fidelity_estimate()
+
+    @property
+    def last_compress_info(self):
+        """Diagnostics from the most recent global lazy compression, if the
+        selected compression backend reported any.
+        """
+        return self._last_compress_info
+
+
 class CircuitPermMPS(CircuitMPS):
     """Quantum circuit simulation keeping the state always in an MPS form, but
     lazily tracking the qubit ordering rather than 'swapping back' qubits after

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -4998,6 +4998,8 @@ def _lazy_mps_flush(circ):
     from .tn1d.compress import tensor_network_1d_compress
 
     kwargs = dict(circ._compress_opts)
+    if circ._compress_method in {"dm", "zipup"}:
+        kwargs.setdefault("check_1d", False)
     info = None
     if circ._compress_method.startswith("fit"):
         info = kwargs.get("info")

--- a/quimb/tensor/tn1d/compress.py
+++ b/quimb/tensor/tn1d/compress.py
@@ -2258,6 +2258,7 @@ def tensor_network_1d_compress_fit(
     inplace_fit=False,
     inplace=False,
     progbar=False,
+    info=None,
     **kwargs,
 ):
     """Compress any 1D-like (can have multiple tensors per site) tensor network
@@ -2355,6 +2356,11 @@ def tensor_network_1d_compress_fit(
         Whether to show a progress bar. Note the progress bar shows the maximum
         change of any single tensor norm, *not* the global change in norm or
         truncation error.
+    info : dict, optional
+        Store fit diagnostics in this dict. Currently records the number of
+        sweeps performed, whether the tolerance criterion was met, the final
+        maximum local tensor change, and for a single target TN the normalized
+        overlap with the compressed result.
     kwargs
         Extra keyword arguments are combined into `compress_opts`, though
         existing items in `compress_opts` take precedence over `kwargs`.
@@ -2501,6 +2507,8 @@ def tensor_network_1d_compress_fit(
 
     # whether to compute the maximum change in tensor norm
     compute_tdiff = (tol != 0.0) or progbar
+    max_tdiff = None
+    converged = False
 
     try:
         for i in its:
@@ -2532,6 +2540,7 @@ def tensor_network_1d_compress_fit(
                 its.set_description(f"max_tdiff={max_tdiff:.2e}")
             if tol != 0.0 and max_tdiff < tol:
                 # converged
+                converged = True
                 break
 
             old_direction = next_direction
@@ -2540,6 +2549,17 @@ def tensor_network_1d_compress_fit(
     finally:
         if progbar:
             its.close()
+
+    if info is not None:
+        info["iterations"] = 0 if max_tdiff is None else i + 1
+        info["max_tdiff"] = max_tdiff
+        info["converged"] = converged
+        if len(tns) == 1:
+            overlap = tn_fit.conj().overlap(tns[0], optimize=optimize)
+            norm_fit = tn_fit.norm(optimize=optimize)
+            norm_target = tns[0].norm(optimize=optimize)
+            if norm_fit and norm_target:
+                info["overlap"] = overlap / (norm_fit * norm_target)
 
     tn_fit.drop_tags("__FIT__")
     tn_fit.conj_()

--- a/quimb/tensor/tn1d/compress.py
+++ b/quimb/tensor/tn1d/compress.py
@@ -387,6 +387,7 @@ def tensor_network_1d_compress_dm(
     max_bond=None,
     cutoff=1e-10,
     site_tags=None,
+    check_1d=True,
     normalize=False,
     cutoff_mode="rsum1",
     permute_arrays=True,
@@ -421,6 +422,9 @@ def tensor_network_1d_compress_dm(
         The tags to use to group and order the tensors from ``tn``. If not
         given, uses ``tn.site_tags``. The tensor network built will have one
         tensor per site, in the order given by ``site_tags``.
+    check_1d : bool, optional
+        Whether to validate and, if necessary, fix the 1D-like bond structure
+        before compressing.
     normalize : bool, optional
         Whether to normalize the final tensor network, making use of the fact
         that the output tensor network is in right canonical form.
@@ -484,7 +488,10 @@ def tensor_network_1d_compress_dm(
         site_tags = tuple(reversed(site_tags))
     N = len(site_tags)
 
-    ket = enforce_1d_like(tn, site_tags=site_tags, inplace=inplace)
+    if check_1d:
+        ket = enforce_1d_like(tn, site_tags=site_tags, inplace=inplace)
+    else:
+        ket = tn if inplace else tn.copy()
 
     # partition outer indices, and create conjugate bra indices
     ket_site_inds = []
@@ -672,6 +679,7 @@ def tensor_network_1d_compress_zipup(
     max_bond=None,
     cutoff=1e-10,
     site_tags=None,
+    check_1d=True,
     canonize=True,
     normalize=False,
     cutoff_mode="rsum2",
@@ -711,6 +719,9 @@ def tensor_network_1d_compress_zipup(
         The tags to use to group and order the tensors from ``tn``. If not
         given, uses ``tn.site_tags``. The tensor network built will have one
         tensor per site, in the order given by ``site_tags``.
+    check_1d : bool, optional
+        Whether to validate and, if necessary, fix the 1D-like bond structure
+        before compressing.
     canonize : bool, optional
         Whether to pseudo canonicalize the initial tensor network.
     normalize : bool, optional
@@ -772,12 +783,10 @@ def tensor_network_1d_compress_zipup(
         site_tags = tuple(reversed(site_tags))
     N = len(site_tags)
 
-    tn = enforce_1d_like(tn, site_tags=site_tags, inplace=inplace)
-
-    # calculate the local site (outer) indices
-    site_inds = [
-        tuple(tn.select(tag)._outer_inds & tn._outer_inds) for tag in site_tags
-    ]
+    if check_1d:
+        tn = enforce_1d_like(tn, site_tags=site_tags, inplace=inplace)
+    else:
+        tn = tn if inplace else tn.copy()
 
     if canonize:
         # put in 'pseudo' left canonical form:
@@ -789,6 +798,11 @@ def tensor_network_1d_compress_zipup(
         #     ▶─▶─▶─▶─▶─▶─▶─▶─▶─○  MPS
         #
         tn = tn.canonize_around_(site_tags[-1], **canonize_opts)
+
+    # calculate the local site (outer) indices
+    site_inds = [
+        tuple(tn.select(tag)._outer_inds & tn._outer_inds) for tag in site_tags
+    ]
 
     # zip along the bonds
     ts = [None] * N

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -1028,6 +1028,23 @@ class TestCircuitMPSLazy:
 
         assert circ.psi.distance_normalized(ref.psi) < 1e-6
 
+    def test_flush_skips_rechecking_1d_structure(self, monkeypatch):
+        import quimb.tensor.tn1d.compress as tn1dc
+
+        def fail_enforce(*args, **kwargs):
+            raise AssertionError("lazy flush should skip enforce_1d_like")
+
+        monkeypatch.setattr(tn1dc, "enforce_1d_like", fail_enforce)
+
+        circ = qtn.CircuitMPSLazy(4, max_bond=16, cutoff=1e-12, method="dm")
+        circ.apply_gate("H", 0)
+        circ.apply_gate("CX", 0, 2)
+
+        psi = circ.psi
+
+        assert isinstance(psi, qtn.MatrixProductState)
+        assert not circ._pending
+
     def test_sample_flushes_pending_state(self):
         circ = qtn.CircuitMPSLazy(2, max_bond=4, method="dm")
         circ.h(0)

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -953,7 +953,7 @@ class TestCircuitMPSLazy:
 
         circ.apply_gate("CX", 0, 5)
         circ.apply_gate("CX", 1, 6)
-        assert circ._pending_sites == {0, 1, 2, 3, 4, 5, 6}
+        assert circ._pending_sites == {1, 2, 3, 4, 5, 6}
 
         circ.apply_gate("CX", 2, 7)
         assert circ._pending_sites == {2, 3, 4, 5, 6, 7}

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -901,3 +901,300 @@ class TestCircuitGen:
 
         energy2 = sum(circ2.local_expectation(ZZ, edge) for edge in terms)
         assert energy2 > 4
+
+
+class TestCircuitMPSLazy:
+    @staticmethod
+    def _random_long_range_gates(N, depth, seed=1):
+        rng = np.random.default_rng(seed)
+        gates = []
+        for _ in range(depth):
+            for i in range(N):
+                gates.append(
+                    qtn.Gate(
+                        "U3", params=rng.uniform(0, 2 * np.pi, size=3), qubits=[i]
+                    )
+                )
+            for i in range(0, N - 1, 2):
+                gates.append(
+                    qtn.Gate(
+                        "SU4",
+                        params=rng.uniform(0, 2 * np.pi, size=15),
+                        qubits=[i, i + 1],
+                    )
+                )
+            a, b = sorted(map(int, rng.choice(N, size=2, replace=False)))
+            gates.append(
+                qtn.Gate.from_raw(
+                    qu.rand_uni(4, seed=int(rng.integers(1 << 30))),
+                    qubits=[a, b],
+                )
+            )
+        return gates
+
+    def test_matches_dense_long_range(self):
+        N = 8
+        gates = self._random_long_range_gates(N, depth=3, seed=42)
+
+        ref = qtn.Circuit(N)
+        ref.apply_gates(gates)
+
+        circ = qtn.CircuitMPSLazy(N, max_bond=2**N, cutoff=1e-12, method="dm")
+        circ.apply_gates(gates)
+
+        psi = circ.psi
+        assert isinstance(psi, qtn.MatrixProductState)
+        assert psi.distance_normalized(ref.psi) < 1e-6
+
+    def test_defers_flush_until_overlap_or_access(self):
+        N = 8
+        rng = np.random.default_rng(7)
+        circ = qtn.CircuitMPSLazy(N, max_bond=8, method="dm")
+
+        circ.apply_gate(
+            qtn.Gate(
+                "SU4",
+                params=rng.uniform(0, 2 * np.pi, size=15),
+                qubits=[0, 1],
+            )
+        )
+        assert circ._pending
+
+        circ.apply_gate(
+            qtn.Gate(
+                "SU4",
+                params=rng.uniform(0, 2 * np.pi, size=15),
+                qubits=[4, 5],
+            )
+        )
+        assert circ._pending
+
+        circ.apply_gate(
+            qtn.Gate(
+                "SU4",
+                params=rng.uniform(0, 2 * np.pi, size=15),
+                qubits=[1, 2],
+            )
+        )
+        assert circ._pending
+
+        psi = circ.psi
+        assert isinstance(psi, qtn.MatrixProductState)
+        assert not circ._pending
+
+    def test_controlled_gate_falls_back_then_recovers(self):
+        N = 6
+        rng = np.random.default_rng(3)
+        gates = [
+            qtn.Gate(
+                "U3", params=rng.uniform(0, 2 * np.pi, size=3), qubits=[i]
+            )
+            for i in range(N)
+        ]
+        gates.append(
+            qtn.Gate(
+                "SU4",
+                params=rng.uniform(0, 2 * np.pi, size=15),
+                qubits=[2, 4],
+                controls=[0],
+            )
+        )
+        gates.append(
+            qtn.Gate(
+                "SU4",
+                params=rng.uniform(0, 2 * np.pi, size=15),
+                qubits=[1, 2],
+            )
+        )
+
+        ref = qtn.Circuit(N)
+        ref.apply_gates(gates)
+
+        circ = qtn.CircuitMPSLazy(N, max_bond=2**N, cutoff=1e-12, method="direct")
+        circ.apply_gates(gates)
+
+        assert circ.psi.distance_normalized(ref.psi) < 1e-6
+
+    @pytest.mark.parametrize("method", ["direct", "zipup"])
+    def test_other_compression_methods_on_small_circuit(self, method):
+        N = 6
+        gates = self._random_long_range_gates(N, depth=2, seed=11)
+
+        ref = qtn.Circuit(N)
+        ref.apply_gates(gates)
+
+        circ = qtn.CircuitMPSLazy(N, max_bond=2**N, cutoff=1e-12, method=method)
+        circ.apply_gates(gates)
+
+        assert circ.psi.distance_normalized(ref.psi) < 1e-6
+
+    def test_sample_flushes_pending_state(self):
+        circ = qtn.CircuitMPSLazy(2, max_bond=4, method="dm")
+        circ.h(0)
+        circ.cx(0, 1)
+        assert circ._pending
+
+        samples = set(circ.sample(32, seed=42))
+
+        assert samples <= {"00", "11"}
+        assert not circ._pending
+
+    def test_local_expectation_flushes_pending_state(self):
+        circ = qtn.CircuitMPSLazy(2, max_bond=4, method="dm")
+        circ.h(0)
+        circ.cx(0, 1)
+        assert circ._pending
+
+        z0 = circ.local_expectation(qu.pauli("Z"), 0)
+        z1 = circ.local_expectation(qu.pauli("Z"), 1)
+
+        assert z0.real == pytest.approx(0.0, abs=1e-6)
+        assert z1.real == pytest.approx(0.0, abs=1e-6)
+        assert not circ._pending
+
+    def test_pending_lazy_gates_keep_gate_tags_before_flush(self):
+        circ = qtn.CircuitMPSLazy(
+            4,
+            max_bond=4,
+            method="dm",
+            tag_gate_numbers=True,
+            tag_gate_rounds=True,
+            tag_gate_labels=True,
+        )
+
+        circ.apply_gate("H", 0, gate_round=3)
+        circ.apply_gate("CX", 0, 2, gate_round=7)
+
+        assert circ._pending
+        assert circ._psi["GATE_0"] is not None
+        assert circ._psi["GATE_1"] is not None
+        assert circ._psi["ROUND_3"] is not None
+        assert circ._psi["ROUND_7"] is not None
+        assert circ._psi["H"] is not None
+        assert circ._psi["CX"] is not None
+
+    def test_2d_ising_trotter_mapping(self):
+        Lx, Ly = 2, 3
+        N = Lx * Ly
+
+        def site(x, y):
+            return x * Ly + y
+
+        bonds = []
+        for x in range(Lx):
+            for y in range(Ly):
+                if y + 1 < Ly:
+                    bonds.append((site(x, y), site(x, y + 1)))
+                if x + 1 < Lx:
+                    bonds.append((site(x, y), site(x + 1, y)))
+
+        dt = 0.1
+        zz = qu.pauli("Z") & qu.pauli("Z")
+        rx = qu.expm(-1j * dt * qu.pauli("X"))
+        rzz = qu.expm(-1j * dt * zz)
+
+        gates = []
+        for _ in range(3):
+            for i in range(N):
+                gates.append(qtn.Gate.from_raw(rx, qubits=[i]))
+            for a, b in bonds:
+                gates.append(qtn.Gate.from_raw(rzz, qubits=[a, b]))
+
+        ref = qtn.Circuit(N)
+        ref.apply_gates(gates)
+
+        circ = qtn.CircuitMPSLazy(N, max_bond=2**N, cutoff=1e-12, method="dm")
+        circ.apply_gates(gates)
+
+        assert circ.psi.distance_normalized(ref.psi) < 1e-6
+
+    def test_fit_method_tracks_generic_error_estimate(self):
+        N = 6
+        gates = self._random_long_range_gates(N, depth=2, seed=21)
+
+        ref = qtn.Circuit(N)
+        ref.apply_gates(gates)
+
+        circ = qtn.CircuitMPSLazy(
+            N,
+            max_bond=4,
+            cutoff=0.0,
+            method="fit",
+            compress_opts={"max_iterations": 2, "tol": 0.0, "optimize": "greedy"},
+        )
+        circ.apply_gates(gates)
+
+        f_est = circ.fidelity_estimate()
+        e_est = circ.error_estimate()
+
+        assert 0.0 <= f_est <= 1.0 + 1e-9
+        assert 0.0 <= e_est <= 1.0 + 1e-9
+        assert e_est == pytest.approx(1 - f_est)
+
+        psi = circ.psi.to_dense().reshape(-1)
+        psi_ref = ref.psi.to_dense().reshape(-1)
+        overlap = abs(np.vdot(psi_ref, psi)) ** 2
+        overlap /= np.vdot(psi_ref, psi_ref).real * np.vdot(psi, psi).real
+
+        # The generic estimate is norm-based rather than a fit-specific overlap,
+        # but it should still be consistent with the actual compressed-state fidelity.
+        assert f_est == pytest.approx(overlap, rel=5e-2, abs=5e-2)
+
+    def test_src_method_on_local_circuit(self):
+        N = 8
+        rng = np.random.default_rng(12)
+        gates = []
+        for _ in range(3):
+            for i in range(N):
+                gates.append(
+                    qtn.Gate(
+                        "U3", params=rng.uniform(0, 2 * np.pi, size=3), qubits=[i]
+                    )
+                )
+            for i in range(0, N - 1, 2):
+                gates.append(
+                    qtn.Gate(
+                        "SU4",
+                        params=rng.uniform(0, 2 * np.pi, size=15),
+                        qubits=[i, i + 1],
+                    )
+                )
+
+        ref = qtn.Circuit(N)
+        ref.apply_gates(gates)
+
+        circ = qtn.CircuitMPSLazy(
+            N,
+            max_bond=2**N,
+            cutoff=0.0,
+            method="src",
+        )
+        circ.apply_gates(gates)
+
+        assert circ.psi.distance_normalized(ref.psi) < 1e-6
+
+    def test_fit_method_reports_last_compress_info(self):
+        N = 6
+        gates = self._random_long_range_gates(N, depth=2, seed=21)
+
+        circ = qtn.CircuitMPSLazy(
+            N,
+            max_bond=4,
+            cutoff=0.0,
+            method="fit",
+            compress_opts={
+                "max_iterations": 2,
+                "tol": 0.0,
+                "optimize": "greedy",
+            },
+        )
+        circ.apply_gates(gates)
+        _ = circ.psi
+
+        info = circ.last_compress_info
+        assert info is not None
+        assert "iterations" in info
+        assert "max_tdiff" in info
+        assert "converged" in info
+        assert "overlap" in info
+        assert 0.0 <= abs(info["overlap"]) <= 1.0 + 1e-9

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -912,7 +912,9 @@ class TestCircuitMPSLazy:
             for i in range(N):
                 gates.append(
                     qtn.Gate(
-                        "U3", params=rng.uniform(0, 2 * np.pi, size=3), qubits=[i]
+                        "U3",
+                        params=rng.uniform(0, 2 * np.pi, size=3),
+                        qubits=[i],
                     )
                 )
             for i in range(0, N - 1, 2):
@@ -946,41 +948,15 @@ class TestCircuitMPSLazy:
         assert isinstance(psi, qtn.MatrixProductState)
         assert psi.distance_normalized(ref.psi) < 1e-6
 
-    def test_defers_flush_until_overlap_or_access(self):
-        N = 8
-        rng = np.random.default_rng(7)
-        circ = qtn.CircuitMPSLazy(N, max_bond=8, method="dm")
+    def test_disjoint_nonlocal_gates_do_not_accumulate_unbounded_span(self):
+        circ = qtn.CircuitMPSLazy(10, max_bond=8, method="zipup")
 
-        circ.apply_gate(
-            qtn.Gate(
-                "SU4",
-                params=rng.uniform(0, 2 * np.pi, size=15),
-                qubits=[0, 1],
-            )
-        )
-        assert circ._pending
+        circ.apply_gate("CX", 0, 5)
+        circ.apply_gate("CX", 1, 6)
+        assert circ._pending_sites == {0, 1, 2, 3, 4, 5, 6}
 
-        circ.apply_gate(
-            qtn.Gate(
-                "SU4",
-                params=rng.uniform(0, 2 * np.pi, size=15),
-                qubits=[4, 5],
-            )
-        )
-        assert circ._pending
-
-        circ.apply_gate(
-            qtn.Gate(
-                "SU4",
-                params=rng.uniform(0, 2 * np.pi, size=15),
-                qubits=[1, 2],
-            )
-        )
-        assert circ._pending
-
-        psi = circ.psi
-        assert isinstance(psi, qtn.MatrixProductState)
-        assert not circ._pending
+        circ.apply_gate("CX", 2, 7)
+        assert circ._pending_sites == {2, 3, 4, 5, 6, 7}
 
     def test_controlled_gate_falls_back_then_recovers(self):
         N = 6
@@ -1010,7 +986,9 @@ class TestCircuitMPSLazy:
         ref = qtn.Circuit(N)
         ref.apply_gates(gates)
 
-        circ = qtn.CircuitMPSLazy(N, max_bond=2**N, cutoff=1e-12, method="direct")
+        circ = qtn.CircuitMPSLazy(
+            N, max_bond=2**N, cutoff=1e-12, method="direct"
+        )
         circ.apply_gates(gates)
 
         assert circ.psi.distance_normalized(ref.psi) < 1e-6
@@ -1023,7 +1001,9 @@ class TestCircuitMPSLazy:
         ref = qtn.Circuit(N)
         ref.apply_gates(gates)
 
-        circ = qtn.CircuitMPSLazy(N, max_bond=2**N, cutoff=1e-12, method=method)
+        circ = qtn.CircuitMPSLazy(
+            N, max_bond=2**N, cutoff=1e-12, method=method
+        )
         circ.apply_gates(gates)
 
         assert circ.psi.distance_normalized(ref.psi) < 1e-6
@@ -1045,28 +1025,52 @@ class TestCircuitMPSLazy:
         assert isinstance(psi, qtn.MatrixProductState)
         assert not circ._pending
 
+    @pytest.mark.parametrize("method", ["dm", "zipup"])
+    def test_windowed_flush_compresses_strict_subwindow(
+        self, monkeypatch, method
+    ):
+        import quimb.tensor.tn1d.compress as tn1dc
+
+        calls = []
+        real_compress = tn1dc.tensor_network_1d_compress
+
+        def wrapped_compress(*args, **kwargs):
+            calls.append(tuple(kwargs.get("site_tags", ())))
+            return real_compress(*args, **kwargs)
+
+        monkeypatch.setattr(
+            tn1dc, "tensor_network_1d_compress", wrapped_compress
+        )
+
+        circ = qtn.CircuitMPSLazy(8, max_bond=16, cutoff=1e-12, method=method)
+        circ.apply_gate("CX", 2, 4)
+        _ = circ.psi
+
+        assert calls
+        assert calls[-1] == ("I2", "I3", "I4")
+
     def test_sample_flushes_pending_state(self):
-        circ = qtn.CircuitMPSLazy(2, max_bond=4, method="dm")
+        circ = qtn.CircuitMPSLazy(3, max_bond=4, method="dm")
         circ.h(0)
-        circ.cx(0, 1)
+        circ.cx(0, 2)
         assert circ._pending
 
         samples = set(circ.sample(32, seed=42))
 
-        assert samples <= {"00", "11"}
+        assert samples <= {"000", "101"}
         assert not circ._pending
 
     def test_local_expectation_flushes_pending_state(self):
-        circ = qtn.CircuitMPSLazy(2, max_bond=4, method="dm")
+        circ = qtn.CircuitMPSLazy(3, max_bond=4, method="dm")
         circ.h(0)
-        circ.cx(0, 1)
+        circ.cx(0, 2)
         assert circ._pending
 
         z0 = circ.local_expectation(qu.pauli("Z"), 0)
-        z1 = circ.local_expectation(qu.pauli("Z"), 1)
+        z2 = circ.local_expectation(qu.pauli("Z"), 2)
 
         assert z0.real == pytest.approx(0.0, abs=1e-6)
-        assert z1.real == pytest.approx(0.0, abs=1e-6)
+        assert z2.real == pytest.approx(0.0, abs=1e-6)
         assert not circ._pending
 
     def test_pending_lazy_gates_keep_gate_tags_before_flush(self):
@@ -1089,6 +1093,18 @@ class TestCircuitMPSLazy:
         assert circ._psi["ROUND_7"] is not None
         assert circ._psi["H"] is not None
         assert circ._psi["CX"] is not None
+
+    def test_repeated_single_gate_overlap_can_fall_back_to_eager(self):
+        circ = qtn.CircuitMPSLazy(6, max_bond=16, cutoff=1e-12, method="zipup")
+
+        circ.apply_gate("CX", 0, 2)
+        assert circ._pending
+
+        circ.apply_gate("CX", 0, 3)
+        assert circ._pending
+
+        circ.apply_gate("CX", 0, 4)
+        assert not circ._pending
 
     def test_2d_ising_trotter_mapping(self):
         Lx, Ly = 2, 3
@@ -1137,7 +1153,11 @@ class TestCircuitMPSLazy:
             max_bond=4,
             cutoff=0.0,
             method="fit",
-            compress_opts={"max_iterations": 2, "tol": 0.0, "optimize": "greedy"},
+            compress_opts={
+                "max_iterations": 2,
+                "tol": 0.0,
+                "optimize": "greedy",
+            },
         )
         circ.apply_gates(gates)
 
@@ -1165,7 +1185,9 @@ class TestCircuitMPSLazy:
             for i in range(N):
                 gates.append(
                     qtn.Gate(
-                        "U3", params=rng.uniform(0, 2 * np.pi, size=3), qubits=[i]
+                        "U3",
+                        params=rng.uniform(0, 2 * np.pi, size=3),
+                        qubits=[i],
                     )
                 )
             for i in range(0, N - 1, 2):


### PR DESCRIPTION
Closes #357 .

## Summary

This adds `CircuitMPSLazy`, a new MPS circuit simulator for circuits with nonlocal gates.

Instead of immediately contracting every nonlocal gate into the state,
`CircuitMPSLazy` converts each such gate into a small MPO over its support and
stacks it lazily on top of the current MPS. The pending structure is then
compressed back into a proper MPS using the existing 1D compression backends,
including `dm`, `zipup`, and `fit`.

This PR also refines the lazy flush heuristics, so that repeated overlapping nonlocal gates can still use a
fast path while disjoint long-range patterns avoid building excessively large
pending windows. It also skips redundant 1D structure checks during flushes.

## Changes

- add `CircuitMPSLazy` as a new circuit simulation interface alongside
  `CircuitMPS` and `CircuitPermMPS`
- represent pending nonlocal gates as lazily stacked MPO fragments rather than eagerly contracting each gate into the MPS
- support flushing through the existing 1D compression methods, including `dm`, `zipup`, and `fit`
- cache dense-gate to MPO conversion for repeated lazy gate application
- add local window flushing for `method="zipup", "dm"` so pending lazy structure can be compressed on a strict subchain instead of always flushing the whole chain
- add a heuristic for `zipup` to prevent disjoint long-range gates from accumulating into a near full-chain pending window
- add an eager fallback for repeated overlapping nonlocal gates in the `zipup` overlap pattern
- skip redundant `enforce_1d_like` checks during lazy flushes
- add regression tests for lazy flush behavior
- add a changelog entry

## Testing

Ran focused tests in `tests/test_tensor/test_circuit.py` covering
`CircuitMPSLazy` behavior.

Ran `benchmark_circuit_mps_lazy.py` and checked:
- `disjoint-long-range`: `zipup` avoids the large runtime / memory blowup
- `star-long-range`: `zipup` keeps the fast overlapping-gate path
- `mapped-ising-2d`: behavior remains stable

## AI Disclosure

I used an AI coding assistant to help draft and refine parts of this PR, including implementation, tests, benchmarks, and the writeup. I made the design decisions and verified the final behavior and results myself.
