### PR TITLE
Add CircuitPEPOSimpleUpdate, a Heisenberg picture PEPO    circuit simulator

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ Release notes for `quimb`.
 - add [`LatticeBondMap`](quimb.tensor.tnag.core.LatticeBondMap): helper for consistently assigning lattice bond indices across ordinary and periodic boundaries, use it in PEPS, PEPO, PEPS3D, scalar 2D/3D lattice tensor-network construction, and classical Ising tensor-network construction.
 - [`eigh_truncated`](quimb.tensor.decomp.eigh_truncated): add a ``shift`` option for optional diagonal regularization.
 - [`Circuit.from_openqasm3_str`](quimb.tensor.circuit.Circuit.from_openqasm3_str), [`Circuit.from_openqasm3_file`](quimb.tensor.circuit.Circuit.from_openqasm3_file), and [`Circuit.from_openqasm3_url`](quimb.tensor.circuit.Circuit.from_openqasm3_url): add OpenQASM 3 parsing with custom gates, register broadcasting, and symbolic input tracking.
+- add [`CircuitPEPOSimpleUpdate`](quimb.tensor.circuit.CircuitPEPOSimpleUpdate): a Heisenberg picture circuit simulator that lazily records gates then evolves an observable backwards in time as an arbitrary geometry PEPO, applying each gate with simple update style gauging and compression via [`tensor_network_ag_gate_simple`](quimb.tensor.tnag.core.tensor_network_ag_gate_simple) and pruning to the reverse lightcone.
 
 
 **Bug fixes:**

--- a/quimb/tensor/__init__.py
+++ b/quimb/tensor/__init__.py
@@ -4,6 +4,7 @@ from .circuit import (
     Circuit,
     CircuitDense,
     CircuitMPS,
+    CircuitPEPOSimpleUpdate,
     CircuitPermMPS,
     Gate,
 )
@@ -241,6 +242,7 @@ __all__ = (
     "Circuit",
     "CircuitDense",
     "CircuitMPS",
+    "CircuitPEPOSimpleUpdate",
     "CircuitPermMPS",
     "cnf_file_parse",
     "connect",

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -38,7 +38,10 @@ from .tensor_builder import (
     HTN_CP_operator_from_products,
     MPO_identity_like,
     MPS_computational_state,
+    TN_from_edges_and_fill_fn,
     TN_from_sites_computational_state,
+    TN_from_sites_product_state,
+    gen_unique_edges,
 )
 from .tensor_core import (
     PTensor,
@@ -2685,8 +2688,7 @@ class Circuit:
 
         if named_updates and not self._named_params:
             raise TypeError(
-                "String-keyed parameters require registered named "
-                "parameters."
+                "String-keyed parameters require registered named parameters."
             )
 
         extra = set(named_updates) - set(self._named_params)
@@ -2800,9 +2802,7 @@ class Circuit:
         qc.apply_gates(info["gates"], progbar=progbar)
         qc.register_named_params(
             {
-                name: (
-                    value if not isinstance(value, str) else float("nan")
-                )
+                name: (value if not isinstance(value, str) else float("nan"))
                 for name, value in info["symbols"].items()
             },
             info["expressions"],
@@ -6068,3 +6068,397 @@ class CircuitDense(Circuit):
         the lightcone is not meaningful.
         """
         return self.psi
+
+
+class CircuitPEPOSimpleUpdate(Circuit):
+    r"""Simulate a circuit in the Heisenberg picture by evolving an observable
+    *backwards* in time as an arbitrary geometry PEPO (projected entangled pair
+    operator), rather than evolving a state forwards.
+
+    Gates are only *recorded* as they are applied - no contraction takes place.
+    The work is deferred until :meth:`local_expectation` is called, at which
+    point the observable is initialized as a bond dimension 1 PEPO on the
+    geometry given by ``edges``, and each recorded gate ``g`` is absorbed in
+    reverse order as the sandwich :math:`O \rightarrow g^\dagger O g` using
+    :func:`~quimb.tensor.tnag.core.tensor_network_ag_gate_simple`, which gauges
+    the local tensors, applies the gate and compresses the affected bond. The
+    evolved operator is then contracted with the initial computational state to
+    give :math:`\langle 0 | U^\dagger G U | 0 \rangle`.
+
+    Because the observable spreads only through its reverse 'lightcone', gates
+    acting entirely outside the operator's current support are skipped - they
+    would contribute :math:`g^\dagger I g = I` - and only the support region is
+    contracted at the end. Local observables of shallow circuits are therefore
+    cheap even on very large geometries.
+
+    Parameters
+    ----------
+    edges : sequence[tuple[hashable, hashable]], optional
+        The nearest neighbor geometry: which pairs of sites are bonded, and so
+        where two site gates may act. ``(u, v)`` and ``(v, u)`` denote the same
+        edge. If not given, ``gates`` must be supplied to infer it.
+    gates : sequence, optional
+        If ``edges`` is not given, infer the geometry from the two site gates in
+        this sequence. The gates are only inspected here, not recorded.
+    max_bond : int, optional
+        The maximum bond dimension to compress the operator to. ``None`` means
+        no limit.
+    cutoff : float, optional
+        The singular value cutoff to use when compressing the operator.
+    gauge_smudge : float, optional
+        Added to the gauges before they are multiplied in and inverted, to
+        avoid numerical issues.
+    gauge_power : float, optional
+        The power to raise the singular values to before gauging.
+    phys_dim : int, optional
+        The physical dimension of each site, 2 by default.
+    dtype : str, optional
+        The data type of the operator tensors.
+    circuit_opts
+        Supplied to :class:`~quimb.tensor.circuit.Circuit`.
+
+    Attributes
+    ----------
+    edges : tuple[tuple[hashable, hashable]]
+        The unique geometry edges.
+    sites : tuple[hashable]
+        The sorted sites appearing in ``edges``.
+
+    Examples
+    --------
+
+    Measure a local observable in the state prepared by a circuit, without
+    ever forming that state::
+
+        edges = [(0, 1), (1, 2), (2, 3)]
+        circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=16)
+        circ.apply_gates(gates)  # recorded, nothing computed yet
+        circ.local_expectation(qu.pauli("Z"), 1)  # evolved and contracted
+
+    See Also
+    --------
+    CircuitMPS, tensor_network_ag_gate_simple
+    """
+
+    def __init__(
+        self,
+        edges=None,
+        *,
+        gates=None,
+        max_bond=None,
+        cutoff=1e-10,
+        gauge_smudge=1e-6,
+        gauge_power=1.0,
+        phys_dim=2,
+        dtype="complex128",
+        **circuit_opts,
+    ):
+        if edges is None:
+            if gates is None:
+                raise ValueError(
+                    "Supply one of `edges` or `gates` to fix the geometry."
+                )
+            # infer the geometry from the two site gates only
+            edges = (
+                g.qubits
+                for g in map(parse_to_gate, gates)
+                if len(g.qubits) == 2
+            )
+        self.edges = tuple(gen_unique_edges(edges))
+        self.sites = tuple(sorted({s for e in self.edges for s in e}))
+        self._edge_set = {frozenset(e) for e in self.edges}
+        self._site_set = set(self.sites)
+        self.phys_dim = phys_dim
+        self._op_dtype = dtype
+        self._su_opts = {
+            "max_bond": max_bond,
+            "cutoff": cutoff,
+            "smudge": gauge_smudge,
+            "power": gauge_power,
+        }
+
+        # gates are recorded not applied, so per-gate tagging is unnecessary
+        circuit_opts.setdefault("tag_gate_numbers", False)
+        circuit_opts.setdefault("tag_gate_rounds", False)
+        circuit_opts.setdefault("tag_gate_labels", False)
+
+        super().__init__(N=len(self.sites), **circuit_opts)
+
+    def _init_state(self, N, dtype="complex128"):
+        # the base class expects a state tensor network; it is never evolved,
+        # but supplies the site structure used to close the operator at the end
+        zero = np.zeros(self.phys_dim, dtype=self._op_dtype)
+        zero[0] = 1.0
+        return TN_from_sites_product_state({site: zero for site in self.sites})
+
+    def copy(self):
+        """Copy the circuit, including its geometry and recorded gates."""
+        new = super().copy()
+        new.edges = self.edges
+        new.sites = self.sites
+        new._edge_set = self._edge_set
+        new._site_set = self._site_set
+        new.phys_dim = self.phys_dim
+        new._op_dtype = self._op_dtype
+        new._su_opts = dict(self._su_opts)
+        return new
+
+    def _apply_gate(self, gate, tags=None, **gate_opts):
+        # Heisenberg picture: just record the gate, deferring all computation
+        if gate.controls:
+            raise NotImplementedError(
+                "Controlled gates are not supported by "
+                "`CircuitPEPOSimpleUpdate`."
+            )
+        if gate.special:
+            raise NotImplementedError(
+                f"The special gate {gate.label!r} has no array form; supply "
+                "it as a raw array instead."
+            )
+
+        where = gate.qubits
+        if len(where) == 1:
+            if where[0] not in self._site_set:
+                raise ValueError(
+                    f"Gate site {where[0]} is not in the geometry."
+                )
+        elif len(where) == 2:
+            if frozenset(where) not in self._edge_set:
+                raise ValueError(
+                    f"Gate on {where} is not a declared nearest neighbor edge."
+                )
+        else:
+            raise ValueError(
+                "Only one and two site gates are supported, but got "
+                f"{len(where)} sites: {where}."
+            )
+
+        self._gates.append(gate)
+
+    def _identity_pepo(self):
+        """Build the identity operator as a bond dimension 1 PEPO on the
+        circuit geometry.
+        """
+        d = self.phys_dim
+        eye = np.eye(d, dtype=self._op_dtype)
+
+        def fill_fn(shape):
+            # shape is (*bond_dims, d, d), every bond dimension being 1
+            return eye.reshape((1,) * (len(shape) - 2) + (d, d))
+
+        return TN_from_edges_and_fill_fn(
+            fill_fn,
+            self.edges,
+            D=1,
+            phys_dim=d,
+            site_ind_id=("k{}", "b{}"),
+        )
+
+    def _parse_where(self, where):
+        try:
+            single = where in self._site_set
+        except TypeError:
+            single = False
+        if single:
+            return (where,)
+
+        if not isinstance(where, (tuple, list)):
+            # a single hashable that is not a known site
+            raise ValueError(
+                f"Observable site {where} is not in the geometry."
+            )
+
+        where = tuple(where)
+        for site in where:
+            if site not in self._site_set:
+                raise ValueError(
+                    f"Observable site {site} is not in the geometry."
+                )
+        if len(where) > 2:
+            raise ValueError(
+                "Observables on more than two sites are not supported."
+            )
+        if (len(where) == 2) and (frozenset(where) not in self._edge_set):
+            raise ValueError(
+                f"Observable on {where} is not a nearest neighbor edge."
+            )
+        return where
+
+    def _evolve_operator(self, G, where):
+        """Build the observable ``G`` at ``where`` and evolve it backwards
+        through all recorded gates, returning the compressed operator, its
+        separately held bond gauges, an overall scale, and the support.
+        """
+        d = self.phys_dim
+        op = self._identity_pepo()
+
+        # seed the operator: G on the upper (ket) indices of the identity
+        op.gate_upper_(
+            np.asarray(G),
+            where,
+            contract=True if len(where) == 1 else "reduce-split",
+        )
+
+        gauges = {}
+        scale = 1.0
+        support = set(where)
+        for gate in reversed(self._gates):
+            qubits = gate.qubits
+            if support.isdisjoint(qubits):
+                # outside the reverse lightcone, g^dagger I g = I
+                continue
+
+            k = len(qubits)
+            gdag = np.asarray(gate.array).reshape(d**k, d**k).conj().T
+
+            # ``info`` exposes the single updated bond's unnormalized singular
+            # values; with ``renorm=False`` these are kept, then the norm is
+            # factored out into ``scale`` to keep the gauges and tensors O(1)
+            info = {}
+            op.gate_simple_(
+                gdag,
+                qubits,
+                gauges,
+                renorm=False,
+                info=info,
+                **self._su_opts,
+            )
+            if info:
+                (_, ix), s = next(iter(info.items()))
+                norm = float(do("linalg.norm", s))
+                if norm > 0.0:
+                    gauges[ix] = s / norm
+                    scale = scale * norm
+
+            support.update(qubits)
+
+        return op, gauges, scale, support
+
+    def local_expectation(self, G, where, *, optimize="auto", **contract_opts):
+        r"""Compute :math:`\langle 0 | U^\dagger G U | 0 \rangle`, the
+        expectation of the observable ``G`` at ``where`` in the state prepared
+        by the recorded circuit ``U``, by evolving the operator backwards and
+        contracting it with the initial all zeros state.
+
+        Parameters
+        ----------
+        G : array_like
+            The local observable, acting on the site(s) in ``where``.
+        where : hashable or sequence[hashable]
+            The site or sites the observable acts on. Each must be in the
+            geometry, and a pair must be a declared edge.
+        optimize : str or PathOptimizer, optional
+            The contraction path optimizer for the final contraction.
+        contract_opts
+            Supplied to
+            :meth:`~quimb.tensor.tensor_core.TensorNetwork.contract`.
+
+        Returns
+        -------
+        scalar
+        """
+        where = self._parse_where(where)
+        op, gauges, scale, support = self._evolve_operator(G, where)
+        op.gauge_simple_insert(gauges)
+
+        # only the reverse lightcone is non-identity; every other site gives
+        # <0|I|0> = 1, so restrict the contraction to the support region
+        tn = op.select(
+            [op.site_tag(site) for site in support], which="any"
+        ).copy()
+
+        zero = np.zeros(self.phys_dim, dtype=self._op_dtype)
+        zero[0] = 1.0
+        for site in support:
+            tn |= Tensor(zero, inds=(op.upper_ind(site),))
+            tn |= Tensor(zero, inds=(op.lower_ind(site),))
+
+        # close the remaining size 1 bonds to the dropped identity region
+        tn.isel_({ix: 0 for ix in tn.outer_inds()})
+
+        return scale * tn.contract(all, optimize=optimize, **contract_opts)
+
+    def compute_local_expectation(
+        self,
+        terms,
+        *,
+        optimize="auto",
+        return_all=False,
+        progbar=False,
+        **contract_opts,
+    ):
+        """Compute many local expectations, each evolved backwards
+        independently.
+
+        Parameters
+        ----------
+        terms : dict[hashable or sequence[hashable], array_like]
+            Mapping of site(s) to the local observable acting there.
+        optimize : str or PathOptimizer, optional
+            The contraction path optimizer for the final contractions.
+        return_all : bool, optional
+            Whether to return all results keyed by location, or just their sum.
+        progbar : bool, optional
+            Whether to show a progress bar over the terms.
+        contract_opts
+            Supplied to
+            :meth:`~quimb.tensor.tensor_core.TensorNetwork.contract`.
+
+        Returns
+        -------
+        scalar or dict[hashable or sequence[hashable], scalar]
+        """
+        terms = dict(terms)
+        keys = tuple(terms)
+        if progbar:
+            keys = _progbar(keys)
+
+        expecs = {
+            where: self.local_expectation(
+                terms[where], where, optimize=optimize, **contract_opts
+            )
+            for where in keys
+        }
+        if return_all:
+            return expecs
+        return sum(expecs.values())
+
+    @property
+    def psi(self):
+        raise NotImplementedError(
+            "`CircuitPEPOSimpleUpdate` works in the Heisenberg picture and "
+            "keeps no explicit forward state; use `local_expectation`."
+        )
+
+    @property
+    def uni(self):
+        raise ValueError(
+            "You can't extract the circuit unitary TN from a "
+            "``CircuitPEPOSimpleUpdate``."
+        )
+
+    def _requires_forward_state(self, *_, **__):
+        raise NotImplementedError(
+            f"`{type(self).__name__}` does not form the explicit forward "
+            "evolved state; use `local_expectation` instead."
+        )
+
+    to_dense = _requires_forward_state
+    amplitude = _requires_forward_state
+    partial_trace = _requires_forward_state
+    sample = _requires_forward_state
+    sample_chaotic = _requires_forward_state
+
+    def calc_qubit_ordering(self, qubits=None):
+        """The PEPO geometry has no inherent linear qubit ordering."""
+        if qubits is None:
+            return tuple(self.sites)
+        return tuple(qubits)
+
+    def __repr__(self):
+        return (
+            f"<CircuitPEPOSimpleUpdate("
+            f"N={self.N}, "
+            f"num_gates={self.num_gates}, "
+            f"max_bond={self._su_opts['max_bond']})>"
+        )

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -6078,7 +6078,7 @@ class CircuitPEPOSimpleUpdate(Circuit):
     Gates are only *recorded* as they are applied - no contraction takes place.
     The work is deferred until :meth:`local_expectation` is called, at which
     point the observable is initialized as a bond dimension 1 PEPO on the
-    geometry given by ``edges``, and each recorded gate ``g`` is absorbed in
+    circuit geometry, and each recorded gate ``g`` is absorbed in
     reverse order as the sandwich :math:`O \rightarrow g^\dagger O g` using
     :func:`~quimb.tensor.tnag.core.tensor_network_ag_gate_simple`, which gauges
     the local tensors, applies the gate and compresses the affected bond. The
@@ -6096,9 +6096,11 @@ class CircuitPEPOSimpleUpdate(Circuit):
     edges : sequence[tuple[hashable, hashable]], optional
         The nearest neighbor geometry: which pairs of sites are bonded, and so
         where two site gates may act. ``(u, v)`` and ``(v, u)`` denote the same
-        edge. If not given, ``gates`` must be supplied to infer it.
+        edge. If neither ``edges`` nor ``gates`` is given, the geometry is built
+        up dynamically from the two site gates as they are applied. Supplying
+        ``edges`` fixes the geometry up front and restricts gates to it.
     gates : sequence, optional
-        If ``edges`` is not given, infer the geometry from the two site gates in
+        Optionally infer a fixed geometry up front from the two site gates in
         this sequence. The gates are only inspected here, not recorded.
     max_bond : int, optional
         The maximum bond dimension to compress the operator to. ``None`` means
@@ -6135,6 +6137,12 @@ class CircuitPEPOSimpleUpdate(Circuit):
         circ.apply_gates(gates)  # recorded, nothing computed yet
         circ.local_expectation(qu.pauli("Z"), 1)  # evolved and contracted
 
+    The geometry can also be left implicit and built up from the gates::
+
+        circ = qtn.CircuitPEPOSimpleUpdate(max_bond=16)
+        circ.apply_gates(gates)  # records the gates and defines the geometry
+        circ.local_expectation(qu.pauli("Z"), 1)
+
     See Also
     --------
     CircuitMPS, tensor_network_ag_gate_simple
@@ -6153,21 +6161,22 @@ class CircuitPEPOSimpleUpdate(Circuit):
         dtype="complex128",
         **circuit_opts,
     ):
-        if edges is None:
-            if gates is None:
-                raise ValueError(
-                    "Supply one of `edges` or `gates` to fix the geometry."
-                )
-            # infer the geometry from the two site gates only
+        if (edges is None) and (gates is not None):
+            # infer a fixed geometry from the two site gates
             edges = (
                 g.qubits
                 for g in map(parse_to_gate, gates)
                 if len(g.qubits) == 2
             )
-        self.edges = tuple(gen_unique_edges(edges))
-        self.sites = tuple(sorted({s for e in self.edges for s in e}))
-        self._edge_set = {frozenset(e) for e in self.edges}
-        self._site_set = set(self.sites)
+
+        # if neither was given the geometry is grown lazily from the gates
+        self._fixed_geometry = edges is not None
+        edges = () if edges is None else tuple(gen_unique_edges(edges))
+
+        self.edges = edges
+        self._edge_set = {frozenset(e) for e in edges}
+        self._site_set = {s for e in edges for s in e}
+        self.sites = self._sorted_sites()
         self.phys_dim = phys_dim
         self._op_dtype = dtype
         self._su_opts = {
@@ -6184,6 +6193,26 @@ class CircuitPEPOSimpleUpdate(Circuit):
 
         super().__init__(N=len(self.sites), **circuit_opts)
 
+    def _sorted_sites(self):
+        try:
+            return tuple(sorted(self._site_set))
+        except TypeError:
+            # sites not mutually comparable, keep an arbitrary stable order
+            return tuple(self._site_set)
+
+    def _register_sites(self, sites):
+        if not self._site_set.issuperset(sites):
+            self._site_set.update(sites)
+            self.sites = self._sorted_sites()
+            self.N = len(self.sites)
+
+    def _register_edge(self, edge):
+        self._register_sites(edge)
+        key = frozenset(edge)
+        if key not in self._edge_set:
+            self._edge_set.add(key)
+            self.edges = (*self.edges, tuple(edge))
+
     def _init_state(self, N, dtype="complex128"):
         # the base class expects a state tensor network; it is never evolved,
         # but supplies the site structure used to close the operator at the end
@@ -6194,10 +6223,11 @@ class CircuitPEPOSimpleUpdate(Circuit):
     def copy(self):
         """Copy the circuit, including its geometry and recorded gates."""
         new = super().copy()
+        new._fixed_geometry = self._fixed_geometry
         new.edges = self.edges
         new.sites = self.sites
-        new._edge_set = self._edge_set
-        new._site_set = self._site_set
+        new._edge_set = set(self._edge_set)
+        new._site_set = set(self._site_set)
         new.phys_dim = self.phys_dim
         new._op_dtype = self._op_dtype
         new._su_opts = dict(self._su_opts)
@@ -6218,15 +6248,22 @@ class CircuitPEPOSimpleUpdate(Circuit):
 
         where = gate.qubits
         if len(where) == 1:
-            if where[0] not in self._site_set:
-                raise ValueError(
-                    f"Gate site {where[0]} is not in the geometry."
-                )
+            if self._fixed_geometry:
+                if where[0] not in self._site_set:
+                    raise ValueError(
+                        f"Gate site {where[0]} is not in the geometry."
+                    )
+            else:
+                self._register_sites(where)
         elif len(where) == 2:
-            if frozenset(where) not in self._edge_set:
-                raise ValueError(
-                    f"Gate on {where} is not a declared nearest neighbor edge."
-                )
+            if self._fixed_geometry:
+                if frozenset(where) not in self._edge_set:
+                    raise ValueError(
+                        f"Gate on {where} is not a declared nearest neighbor "
+                        "edge."
+                    )
+            else:
+                self._register_edge(where)
         else:
             raise ValueError(
                 "Only one and two site gates are supported, but got "
@@ -6235,9 +6272,10 @@ class CircuitPEPOSimpleUpdate(Circuit):
 
         self._gates.append(gate)
 
-    def _identity_pepo(self):
+    def _identity_pepo(self, extra_sites=()):
         """Build the identity operator as a bond dimension 1 PEPO on the
-        circuit geometry.
+        circuit geometry. Any sites not connected by an edge (including those in
+        ``extra_sites``) are added as lone identity tensors.
         """
         d = self.phys_dim
         eye = np.eye(d, dtype=self._op_dtype)
@@ -6246,13 +6284,31 @@ class CircuitPEPOSimpleUpdate(Circuit):
             # shape is (*bond_dims, d, d), every bond dimension being 1
             return eye.reshape((1,) * (len(shape) - 2) + (d, d))
 
-        return TN_from_edges_and_fill_fn(
-            fill_fn,
-            self.edges,
-            D=1,
-            phys_dim=d,
-            site_ind_id=("k{}", "b{}"),
-        )
+        if self.edges:
+            op = TN_from_edges_and_fill_fn(
+                fill_fn,
+                self.edges,
+                D=1,
+                phys_dim=d,
+                site_ind_id=("k{}", "b{}"),
+            )
+        else:
+            op = TensorNetworkGenOperator.new(
+                sites=(),
+                site_tag_id="I{}",
+                upper_ind_id="k{}",
+                lower_ind_id="b{}",
+            )
+
+        edge_sites = {s for e in self.edges for s in e}
+        for site in (self._site_set | set(extra_sites)) - edge_sites:
+            op |= Tensor(
+                eye,
+                inds=(op.upper_ind(site), op.lower_ind(site)),
+                tags=(op.site_tag(site),),
+            )
+
+        return op
 
     def _parse_where(self, where):
         try:
@@ -6263,22 +6319,23 @@ class CircuitPEPOSimpleUpdate(Circuit):
             return (where,)
 
         if not isinstance(where, (tuple, list)):
-            # a single hashable that is not a known site
-            raise ValueError(
-                f"Observable site {where} is not in the geometry."
-            )
+            # a single hashable site not currently in the geometry
+            if self._fixed_geometry:
+                raise ValueError(
+                    f"Observable site {where} is not in the geometry."
+                )
+            # with dynamic geometry an untouched site is allowed
+            return (where,)
 
         where = tuple(where)
-        for site in where:
-            if site not in self._site_set:
-                raise ValueError(
-                    f"Observable site {site} is not in the geometry."
-                )
+        if len(where) == 1:
+            return self._parse_where(where[0])
         if len(where) > 2:
             raise ValueError(
                 "Observables on more than two sites are not supported."
             )
-        if (len(where) == 2) and (frozenset(where) not in self._edge_set):
+        # a two site observable must lie on an existing edge
+        if frozenset(where) not in self._edge_set:
             raise ValueError(
                 f"Observable on {where} is not a nearest neighbor edge."
             )
@@ -6290,7 +6347,7 @@ class CircuitPEPOSimpleUpdate(Circuit):
         separately held bond gauges, an overall scale, and the support.
         """
         d = self.phys_dim
-        op = self._identity_pepo()
+        op = self._identity_pepo(extra_sites=where)
 
         # seed the operator: G on the upper (ket) indices of the identity
         op.gate_upper_(

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -1794,6 +1794,36 @@ class TestCircuitPEPOSimpleUpdate:
         circ.apply_gates(gates)
         assert circ.num_gates == 3
 
+    def test_dynamic_geometry_no_edges(self):
+        # the issue's headline API: no edges, geometry grows from the gates
+        N = 4
+        edges = [(i, i + 1) for i in range(N - 1)]
+        gates = self._random_gates(range(N), edges, depth=2, seed=3)
+
+        circ = qtn.CircuitPEPOSimpleUpdate(max_bond=2**N)
+        assert circ.num_gates == 0
+        assert circ.sites == ()
+        circ.apply_gates(gates)
+        # the geometry was built up from the gates
+        assert set(circ.sites) == set(range(N))
+        assert {frozenset(e) for e in circ.edges} == {
+            frozenset(e) for e in edges
+        }
+
+        v = circ.local_expectation(qu.pauli("Z"), 1)
+        r = self._exact(N, (1,), qu.pauli("Z"), gates)
+        assert complex(v) == pytest.approx(r, abs=1e-8)
+
+    def test_empty_dynamic_circuit(self):
+        # no gates and no edges: an untouched site gives <0|Z|0>=1, <0|X|0>=0
+        circ = qtn.CircuitPEPOSimpleUpdate(max_bond=8)
+        assert complex(
+            circ.local_expectation(qu.pauli("Z"), 0)
+        ) == pytest.approx(1.0, abs=1e-12)
+        assert complex(
+            circ.local_expectation(qu.pauli("X"), 0)
+        ) == pytest.approx(0.0, abs=1e-12)
+
     def test_reversed_edge_ordering(self):
         # edges given as (v, u) should accept gates specified as (u, v)
         N = 4
@@ -1849,10 +1879,7 @@ class TestCircuitPEPOSimpleUpdate:
         circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=8)
 
         with pytest.raises(ValueError):
-            # neither edges nor gates supplied
-            qtn.CircuitPEPOSimpleUpdate()
-        with pytest.raises(ValueError):
-            # single site gate off the geometry
+            # single site gate off a fixed geometry
             circ.apply_gate(qtn.Gate.from_raw(qu.rand_uni(2), qubits=[7]))
         with pytest.raises(ValueError):
             # two site gate not on an edge

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -546,11 +546,11 @@ class TestCircuit:
         assert params["theta"] == pytest.approx(0.6)
 
         circ2 = unpack({"theta": np.array(0.2)}, skeleton)
-        assert tuple(circ2.gates[0].params) == pytest.approx(
-            (math.cos(0.1),)
-        )
+        assert tuple(circ2.gates[0].params) == pytest.approx((math.cos(0.1),))
 
-    def test_openqasm3_named_binding_rejects_direct_managed_gate_override(self):
+    def test_openqasm3_named_binding_rejects_direct_managed_gate_override(
+        self,
+    ):
         circ = qtn.Circuit.from_openqasm3_str(
             """
             OPENQASM 3.0;
@@ -579,9 +579,7 @@ class TestCircuit:
 
         circ.set_params({"theta": np.array(0.6)})
         assert tuple(circ.gates[0].params) == pytest.approx((0.6,))
-        assert tuple(circ.gates[1].params) == pytest.approx(
-            (math.cos(0.3),)
-        )
+        assert tuple(circ.gates[1].params) == pytest.approx((math.cos(0.3),))
 
     def test_circuit_register_named_params_sequence_and_callable(self):
         circ = qtn.Circuit(1)
@@ -618,18 +616,14 @@ class TestCircuit:
         circ = qtn.Circuit(1)
         circ.rx(0.1, 0)
 
-        with pytest.raises(
-            ValueError, match="got non-parametrized gate: 0"
-        ):
+        with pytest.raises(ValueError, match="got non-parametrized gate: 0"):
             circ.register_named_params({"theta": np.nan}, {0: ("theta",)})
 
     def test_circuit_register_named_params_rejects_wrong_arity(self):
         circ = qtn.Circuit(1)
         circ.rx(np.nan, 0, parametrize=True)
 
-        with pytest.raises(
-            ValueError, match="expected 1, got 2"
-        ):
+        with pytest.raises(ValueError, match="expected 1, got 2"):
             circ.register_named_params(
                 {"theta": np.nan},
                 {0: ("theta", "theta")},
@@ -1599,3 +1593,312 @@ class TestCircuitGen:
 
         energy2 = sum(circ2.local_expectation(ZZ, edge) for edge in terms)
         assert energy2 > 4
+
+
+class TestCircuitPEPOSimpleUpdate:
+    @staticmethod
+    def _grid_edges(Lx, Ly):
+        edges = []
+        for x in range(Lx):
+            for y in range(Ly):
+                if x + 1 < Lx:
+                    edges.append(((x, y), (x + 1, y)))
+                if y + 1 < Ly:
+                    edges.append(((x, y), (x, y + 1)))
+        return edges
+
+    @staticmethod
+    def _random_gates(sites, edges, depth, seed):
+        rng = np.random.default_rng(seed)
+        gates = []
+        for _ in range(depth):
+            for s in sites:
+                gates.append(
+                    qtn.Gate.from_raw(
+                        qu.rand_uni(2, seed=int(rng.integers(1 << 30))),
+                        qubits=[s],
+                    )
+                )
+            for a, b in edges:
+                gates.append(
+                    qtn.Gate.from_raw(
+                        qu.rand_uni(4, seed=int(rng.integers(1 << 30))),
+                        qubits=[a, b],
+                    )
+                )
+        return gates
+
+    @staticmethod
+    def _exact(N, where, obs, gates, qmap=None):
+        """Independent dense reference ``<0| U^dag G U |0>``."""
+        qmap = qmap or {}
+
+        def q(s):
+            return qmap.get(s, s)
+
+        U = np.eye(2**N, dtype=complex)
+        for g in gates:
+            k = len(g.qubits)
+            U = (
+                qu.pkron(
+                    np.asarray(g.array, dtype=complex).reshape(2**k, 2**k),
+                    [2] * N,
+                    [q(s) for s in g.qubits],
+                )
+                @ U
+            )
+        m = len(where)
+        Of = qu.pkron(
+            np.asarray(obs, dtype=complex).reshape(2**m, 2**m),
+            [2] * N,
+            [q(s) for s in where],
+        )
+        p = qu.basis_vec(0, 2**N)
+        return complex((p.conj().T @ (U.conj().T @ Of @ U) @ p)[0, 0])
+
+    @pytest.mark.parametrize("obs", ["X", "Y", "Z"])
+    def test_matches_dense_chain(self, obs):
+        N = 4
+        edges = [(i, i + 1) for i in range(N - 1)]
+        gates = self._random_gates(range(N), edges, depth=3, seed=42)
+
+        circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=2**N)
+        circ.apply_gates(gates)
+
+        v = circ.local_expectation(qu.pauli(obs), 1)
+        r = self._exact(N, (1,), qu.pauli(obs), gates)
+        assert complex(v) == pytest.approx(r, abs=1e-8)
+
+    def test_two_site_observable(self):
+        N = 4
+        edges = [(i, i + 1) for i in range(N - 1)]
+        gates = self._random_gates(range(N), edges, depth=3, seed=11)
+
+        circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=2**N)
+        circ.apply_gates(gates)
+
+        zz = qu.pauli("Z") & qu.pauli("Z")
+        v = circ.local_expectation(zz, (1, 2))
+        r = self._exact(N, (1, 2), zz, gates)
+        assert complex(v) == pytest.approx(r, abs=1e-8)
+
+    def test_matches_dense_loop(self):
+        # simple update is exact when no bond is truncated; a 4-cycle needs a
+        # larger bond than a chain to avoid truncation and recover the exact
+        # value
+        edges = [(0, 1), (1, 2), (2, 3), (0, 3)]
+        gates = self._random_gates([], edges, depth=2, seed=0)
+
+        circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=64)
+        circ.apply_gates(gates)
+
+        v = circ.local_expectation(qu.pauli("X"), 2)
+        r = self._exact(4, (2,), qu.pauli("X"), gates)
+        assert complex(v) == pytest.approx(r, abs=1e-8)
+
+    def test_matches_dense_2d_grid(self):
+        # vertical bonds of a 2x3 grid are long range in any 1D ordering
+        edges = self._grid_edges(2, 3)
+        sites = sorted({s for e in edges for s in e})
+        qmap = {s: i for i, s in enumerate(sites)}
+        N = len(sites)
+        gates = self._random_gates(sites, edges, depth=2, seed=7)
+
+        circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=2**N)
+        circ.apply_gates(gates)
+
+        v = circ.local_expectation(qu.pauli("Z"), (0, 1))
+        r = self._exact(N, ((0, 1),), qu.pauli("Z"), gates, qmap=qmap)
+        assert complex(v) == pytest.approx(r, abs=1e-7)
+
+    def test_apply_gates_is_lazy(self):
+        edges = [(0, 1), (1, 2)]
+        circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=8)
+        assert circ.num_gates == 0
+
+        gates = self._random_gates(range(3), edges, depth=2, seed=1)
+        circ.apply_gates(gates)
+        assert circ.num_gates == len(gates)
+        assert circ.gates == tuple(gates)
+
+    def test_empty_circuit(self):
+        edges = [(0, 1), (1, 2)]
+        circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=8)
+        assert complex(
+            circ.local_expectation(qu.pauli("Z"), 0)
+        ) == pytest.approx(1.0, abs=1e-12)
+        assert complex(
+            circ.local_expectation(qu.pauli("X"), 0)
+        ) == pytest.approx(0.0, abs=1e-12)
+
+    def test_lightcone_pruning(self):
+        # observable on site 0, all gates act on the far end of the chain, so
+        # they lie outside the reverse lightcone and must not change <0|Z|0>=1
+        edges = [(i, i + 1) for i in range(5)]
+        gates = self._random_gates([3, 4, 5], [(3, 4), (4, 5)], 3, seed=9)
+
+        circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=8)
+        circ.apply_gates(gates)
+        v = circ.local_expectation(qu.pauli("Z"), 0)
+        assert complex(v) == pytest.approx(1.0, abs=1e-12)
+
+    def test_single_site_gates_only(self):
+        # single site gates take the single-tensor path and never gauge a bond
+        N = 3
+        edges = [(0, 1), (1, 2)]
+        rng = np.random.default_rng(4)
+        gates = [
+            qtn.Gate.from_raw(
+                qu.rand_uni(2, seed=int(rng.integers(1 << 30))), qubits=[i]
+            )
+            for _ in range(3)
+            for i in range(N)
+        ]
+        circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=4)
+        circ.apply_gates(gates)
+        v = circ.local_expectation(qu.pauli("Y"), 1)
+        r = self._exact(N, (1,), qu.pauli("Y"), gates)
+        assert complex(v) == pytest.approx(r, abs=1e-9)
+
+    def test_truncation_and_exactness(self):
+        N = 5
+        edges = [(i, i + 1) for i in range(N - 1)]
+        gates = self._random_gates(range(N), edges, depth=4, seed=7)
+        ref = self._exact(N, (2,), qu.pauli("Z"), gates)
+
+        circ = qtn.CircuitPEPOSimpleUpdate(edges)
+        circ.apply_gates(gates)
+
+        # a small bond truncates the operator and is only approximate
+        err_small = abs(
+            complex(circ.local_expectation(qu.pauli("Z"), 2, max_bond=2)) - ref
+        )
+        assert err_small > 1e-6
+
+        # a chain is a tree, so a large enough bond recovers the exact value
+        err_large = abs(
+            complex(circ.local_expectation(qu.pauli("Z"), 2, max_bond=2**N))
+            - ref
+        )
+        assert err_large < 1e-8
+
+    def test_geometry_inferred_from_gates(self):
+        gates = [
+            qtn.Gate.from_raw(qu.rand_uni(2), qubits=[0]),
+            qtn.Gate.from_raw(qu.rand_uni(4), qubits=[0, 1]),
+            qtn.Gate.from_raw(qu.rand_uni(4), qubits=[1, 2]),
+        ]
+        circ = qtn.CircuitPEPOSimpleUpdate(gates=gates, max_bond=8)
+        assert set(circ.sites) == {0, 1, 2}
+        assert set(circ.edges) == {(0, 1), (1, 2)}
+        circ.apply_gates(gates)
+        assert circ.num_gates == 3
+
+    def test_reversed_edge_ordering(self):
+        # edges given as (v, u) should accept gates specified as (u, v)
+        N = 4
+        edges = [(i + 1, i) for i in range(N - 1)]
+        rng = np.random.default_rng(2)
+        gates = [
+            qtn.Gate.from_raw(
+                qu.rand_uni(4, seed=int(rng.integers(1 << 30))),
+                qubits=[i, i + 1],
+            )
+            for i in range(N - 1)
+        ]
+        circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=2**N)
+        circ.apply_gates(gates)
+        v = circ.local_expectation(qu.pauli("Z"), 0)
+        r = self._exact(N, (0,), qu.pauli("Z"), gates)
+        assert complex(v) == pytest.approx(r, abs=1e-8)
+
+    def test_compute_local_expectation(self):
+        N = 4
+        edges = [(i, i + 1) for i in range(N - 1)]
+        gates = self._random_gates(range(N), edges, depth=2, seed=5)
+
+        circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=2**N)
+        circ.apply_gates(gates)
+
+        terms = {i: qu.pauli("Z") for i in range(N)}
+        all_expecs = circ.compute_local_expectation(terms, return_all=True)
+        assert set(all_expecs) == set(range(N))
+        total = circ.compute_local_expectation(terms)
+        assert complex(total) == pytest.approx(
+            sum(complex(v) for v in all_expecs.values()), abs=1e-10
+        )
+        for i in range(N):
+            r = self._exact(N, (i,), qu.pauli("Z"), gates)
+            assert complex(all_expecs[i]) == pytest.approx(r, abs=1e-8)
+
+    def test_copy_is_independent(self):
+        edges = [(0, 1), (1, 2)]
+        circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=8)
+        circ.apply_gates(self._random_gates(range(3), edges, 1, seed=2))
+
+        other = circ.copy()
+        n_before = circ.num_gates
+        other.apply_gate(qtn.Gate.from_raw(qu.rand_uni(4), qubits=[0, 1]))
+
+        assert circ.num_gates == n_before
+        assert other.num_gates == n_before + 1
+        assert other.edges == circ.edges
+
+    def test_validation(self):
+        edges = [(0, 1), (1, 2)]
+        circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=8)
+
+        with pytest.raises(ValueError):
+            # neither edges nor gates supplied
+            qtn.CircuitPEPOSimpleUpdate()
+        with pytest.raises(ValueError):
+            # single site gate off the geometry
+            circ.apply_gate(qtn.Gate.from_raw(qu.rand_uni(2), qubits=[7]))
+        with pytest.raises(ValueError):
+            # two site gate not on an edge
+            circ.apply_gate(qtn.Gate.from_raw(qu.rand_uni(4), qubits=[0, 2]))
+        with pytest.raises(ValueError):
+            # three site gate
+            circ.apply_gate(
+                qtn.Gate.from_raw(qu.rand_uni(8), qubits=[0, 1, 2])
+            )
+        with pytest.raises(NotImplementedError):
+            # controlled gate
+            circ.apply_gate(
+                qtn.Gate.from_raw(qu.rand_uni(2), qubits=[1], controls=[0])
+            )
+        with pytest.raises(ValueError):
+            # observable off the geometry
+            circ.local_expectation(qu.pauli("Z"), 5)
+        with pytest.raises(ValueError):
+            # two site observable not on an edge
+            circ.local_expectation(qu.pauli("Z") & qu.pauli("Z"), (0, 2))
+        with pytest.raises(ValueError):
+            # observable on more than two sites
+            circ.local_expectation(qu.eye(8), (0, 1, 2))
+
+    def test_unsupported_forward_state_methods(self):
+        edges = [(0, 1), (1, 2)]
+        circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=8)
+        with pytest.raises(NotImplementedError):
+            circ.psi
+        with pytest.raises(ValueError):
+            circ.uni
+        for method in ("to_dense", "amplitude", "sample"):
+            with pytest.raises(NotImplementedError):
+                getattr(circ, method)()
+
+    def test_large_lattice_local_observable_is_cheap(self):
+        # reverse-lightcone pruning and support-restricted contraction keep a
+        # local observable of a shallow circuit tractable beyond exact sizes
+        L = 10
+        edges = self._grid_edges(L, L)
+        sites = sorted({s for e in edges for s in e})
+        gates = self._random_gates(sites, edges, depth=2, seed=2)
+
+        circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=8)
+        circ.apply_gates(gates)
+        v = complex(circ.local_expectation(qu.pauli("Z"), (L // 2, L // 2)))
+        assert np.isfinite(v.real)
+        assert abs(v.imag) < 1e-8
+        assert abs(v.real) <= 1.0 + 1e-8


### PR DESCRIPTION
Closes #359.

This adds CircuitPEPOSimpleUpdate, a Circuit subclass that evolves an observable backwards in time as an arbitrary geometry PEPO instead of evolving a state forwards.

 Gates are recorded lazily - nothing is computed when they are applied. The work happens on local_expectation(G, where): the observable is built as a bond dimension 1 PEPO on the geometry, each recorded gate g is absorbed in reverse order as the sandwich O -> g† O g via tensor_network_ag_gate_simple (simple update gauging and compression), and the evolved operator is contracted with the all zeros state to give <0| U† G U |0>.
 
 edges = [(0, 1), (1, 2), (2, 3)]
 circ = qtn.CircuitPEPOSimpleUpdate(edges, max_bond=16)
 circ.apply_gates(gates)                     # recorded, nothing computed
  circ.local_expectation(qu.pauli("Z"), 1)    # evolved and contracted
 
 Notes:
 - Geometry comes from an explicit edges list, or is inferred from the two site gates if only gates are given.
 - Gates outside the observable's reverse lightcone are skipped (g† I g = I) and only the support is contracted, so local observables of shallow circuits stay cheap on large lattices.
- The operator scale is factored out of the gauges as gates are applied (using the singular values surfaced in info) to keep the tensors O(1).
- One and two site gates only; controlled, special and 3+ site gates raise. Methods needing the explicit forward state (psi, 
to_dense, sample, ...) raise rather than mislead.
- Adds compute_local_expectation for many terms, plus a changelog entry.

Tests in TestCircuitPEPOSimpleUpdate check against a dense <0| U† G U |0> reference on chains, a 4-cycle, and a 2D grid (bonds long range in any 1D ordering), plus lightcone pruning, truncation vs exactness, geometry inference, validation, and the unsupported methods.

AI disclosure: Built in collaboration with Claude Code. I drove the design - the backwards Heisenberg evolution as a PEPO, the reverse lightcone pruning, and keeping the operator scale out of the gauges - and used it to move fast on the implementation and tests. I reviewed everything and checked the results against exact dense references before opening this PR.