### PR TITLE
tn1d compress: fixes for long range bond compressions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,8 @@ Release notes for `quimb`.
 
 **Bug fixes:**
 
+- [`tensor_network_1d_compress_src`](quimb.tensor.tn1d.compress.tensor_network_1d_compress_src) and [`tensor_network_1d_compress_srcmps`](quimb.tensor.tn1d.compress.tensor_network_1d_compress_srcmps): call [`enforce_1d_like`](quimb.tensor.tn1d.compress.enforce_1d_like) like the other 1D compression methods, fixing compression of tensor networks with long range (site skipping) bonds, e.g. from lazily applied long range gates.
+- [`enforce_1d_like`](quimb.tensor.tn1d.compress.enforce_1d_like): fix the identity string insertion for long range bonds when the supplied ``site_tags`` order the two tensors in reverse (e.g. with ``sweep_reverse=True``), which previously wired the identities to the wrong sites.
 - [`PEPS`](quimb.tensor.tn2d.core.PEPS), [`PEPO`](quimb.tensor.tn2d.core.PEPO), and [`PEPS3D`](quimb.tensor.tn3d.core.PEPS3D): fix periodic construction for length-1 and length-2 cyclic dimensions so normal and periodic bonds remain distinct, including bond-dimension-1 cyclic tensors.
 - [`TensorNetwork2DVector.compute_norm`](quimb.tensor.tn2d.core.TensorNetwork2DVector.compute_norm): ensure we always return a scalar rather than unwrapped tensor network.
 

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -2685,8 +2685,7 @@ class Circuit:
 
         if named_updates and not self._named_params:
             raise TypeError(
-                "String-keyed parameters require registered named "
-                "parameters."
+                "String-keyed parameters require registered named parameters."
             )
 
         extra = set(named_updates) - set(self._named_params)
@@ -2800,9 +2799,7 @@ class Circuit:
         qc.apply_gates(info["gates"], progbar=progbar)
         qc.register_named_params(
             {
-                name: (
-                    value if not isinstance(value, str) else float("nan")
-                )
+                name: (value if not isinstance(value, str) else float("nan"))
                 for name, value in info["symbols"].items()
             },
             info["expressions"],

--- a/quimb/tensor/tn1d/compress.py
+++ b/quimb/tensor/tn1d/compress.py
@@ -100,6 +100,7 @@ def enforce_1d_like(tn, site_tags=None, fix_bonds=True, inplace=False):
         sb = _check_tensor_site(tidb, tb)
         if sa > sb:
             sa, sb = sb, sa
+            ta, tb = tb, ta
 
         if sb - sa > 1:
             if not fix_bonds:
@@ -115,11 +116,7 @@ def enforce_1d_like(tn, site_tags=None, fix_bonds=True, inplace=False):
             ixl = ix
             for i in range(sa + 1, sb):
                 ixr = rand_uuid()
-                tn |= Tensor(
-                    data=data,
-                    inds=[ixl, ixr],
-                    tags=site_tags[i],
-                )
+                tn |= Tensor(data=data, inds=[ixl, ixr], tags=site_tags[i])
                 ixl = ixr
 
             tb.reindex_({ix: ixl})
@@ -1382,6 +1379,8 @@ def tensor_network_1d_compress_src(
         site_tags = tuple(reversed(site_tags))
     L = len(site_tags)
 
+    tn = enforce_1d_like(tn, site_tags=site_tags, inplace=inplace)
+
     # first we segment the tensor network into local sites
     local_tns = []
     local_inds = []
@@ -1703,6 +1702,8 @@ def tensor_network_1d_compress_srcmps(
     if sweep_reverse:
         site_tags = tuple(reversed(site_tags))
     L = len(site_tags)
+
+    tn = enforce_1d_like(tn, site_tags=site_tags, inplace=inplace)
 
     local_tns = []
     for i in range(L):

--- a/tests/test_tensor/test_circuit.py
+++ b/tests/test_tensor/test_circuit.py
@@ -546,11 +546,11 @@ class TestCircuit:
         assert params["theta"] == pytest.approx(0.6)
 
         circ2 = unpack({"theta": np.array(0.2)}, skeleton)
-        assert tuple(circ2.gates[0].params) == pytest.approx(
-            (math.cos(0.1),)
-        )
+        assert tuple(circ2.gates[0].params) == pytest.approx((math.cos(0.1),))
 
-    def test_openqasm3_named_binding_rejects_direct_managed_gate_override(self):
+    def test_openqasm3_named_binding_rejects_direct_managed_gate_override(
+        self,
+    ):
         circ = qtn.Circuit.from_openqasm3_str(
             """
             OPENQASM 3.0;
@@ -579,9 +579,7 @@ class TestCircuit:
 
         circ.set_params({"theta": np.array(0.6)})
         assert tuple(circ.gates[0].params) == pytest.approx((0.6,))
-        assert tuple(circ.gates[1].params) == pytest.approx(
-            (math.cos(0.3),)
-        )
+        assert tuple(circ.gates[1].params) == pytest.approx((math.cos(0.3),))
 
     def test_circuit_register_named_params_sequence_and_callable(self):
         circ = qtn.Circuit(1)
@@ -618,18 +616,14 @@ class TestCircuit:
         circ = qtn.Circuit(1)
         circ.rx(0.1, 0)
 
-        with pytest.raises(
-            ValueError, match="got non-parametrized gate: 0"
-        ):
+        with pytest.raises(ValueError, match="got non-parametrized gate: 0"):
             circ.register_named_params({"theta": np.nan}, {0: ("theta",)})
 
     def test_circuit_register_named_params_rejects_wrong_arity(self):
         circ = qtn.Circuit(1)
         circ.rx(np.nan, 0, parametrize=True)
 
-        with pytest.raises(
-            ValueError, match="expected 1, got 2"
-        ):
+        with pytest.raises(ValueError, match="expected 1, got 2"):
             circ.register_named_params(
                 {"theta": np.nan},
                 {0: ("theta", "theta")},

--- a/tests/test_tensor/test_tn1d/test_compress.py
+++ b/tests/test_tensor/test_tn1d/test_compress.py
@@ -110,24 +110,49 @@ def test_basic_compress_double_mpo(
     [
         "direct",
         "dm",
-        "fit",
         "zipup",
         "zipup-first",
+        "zipup-oversample",
+        "src",
+        "src-first",
+        "src-oversample",
+        "srcmps",
+        "srcmps-first",
+        "srcmps-oversample",
+        "fit",
+        "fit-zipup",
+        "fit-projector",
+        "fit-oversample",
     ],
 )
 @pytest.mark.parametrize("dtype", dtypes)
-def test_mps_partial_mpo_apply(method, dtype):
+@pytest.mark.parametrize("sweep_reverse", [False, True])
+def test_mps_partial_mpo_apply(method, dtype, sweep_reverse):
+    # the sub-MPO has tensors only at `where`, so the lazily gated MPS has a
+    # long range (site skipping) bond, which every method should handle via
+    # `enforce_1d_like`
     mps = qtn.MPS_rand_state(10, 7, dtype=dtype)
     A = qu.rand_uni(2**3, dtype=dtype)
     where = [8, 4, 5]
     mpo = qtn.MatrixProductOperator.from_dense(A, sites=where)
     new = mps.gate_with_op_lazy(mpo)
     assert (
-        qtn.tensor_network_1d_compress(new, method=method, inplace=True) is new
+        qtn.tensor_network_1d_compress(
+            new,
+            max_bond=32,
+            method=method,
+            sweep_reverse=sweep_reverse,
+            inplace=True,
+        )
+        is new
     )
     assert new.num_tensors == 10
+    eps = 1e-3 if dtype in ("float32", "complex64") else 1e-6
+    if "src" in method:
+        # account for noise
+        eps *= 5
     assert new.distance_normalized(mps.gate(A, where)) == pytest.approx(
-        0.0, abs=1e-3 if dtype in ("float32", "complex64") else 1e-6
+        0.0, abs=eps
     )
 
 


### PR DESCRIPTION
`tensor_network_1d_compress` had two bugs relating to compressing long range bonds:

- the `src` and `srcmps` methods didn't call `enforce_1d_like`
- in `enforce_1d_like`, out of order sites were incorrectly wired up.

This PR fixes both. Relevant for issue #377, and PRs #372, #376 and #377.