### PR TITLE
 circuit: fix dense/perm-mps observables, add dense controlled gates

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,9 +17,13 @@ Release notes for `quimb`.
 - [`eigh_truncated`](quimb.tensor.decomp.eigh_truncated): add a ``shift`` option for optional diagonal regularization.
 - [`CircuitMPSLazy`](quimb.tensor.circuit.CircuitMPSLazy): add a MPS-based circuit simulator using lazily evaluated gates and periodic automated compression, performing better compared to `CircuitMPS` for long-range gates when using `src` compression method.
 - [`Circuit.from_openqasm3_str`](quimb.tensor.circuit.Circuit.from_openqasm3_str), [`Circuit.from_openqasm3_file`](quimb.tensor.circuit.Circuit.from_openqasm3_file), and [`Circuit.from_openqasm3_url`](quimb.tensor.circuit.Circuit.from_openqasm3_url): add OpenQASM 3 parsing with custom gates, register broadcasting, and symbolic input tracking.
+- [`CircuitDense`](quimb.tensor.circuit.CircuitDense): support controlled gates supplied via the ``controls=`` kwarg, by inserting the low-rank hyper tensor network representation of the gate and contracting it into the dense state (avoiding ever forming the full dense operator).
 
 
 **Bug fixes:**
+
+- [`CircuitDense`](quimb.tensor.circuit.CircuitDense): fix `psi`, `partial_trace` and `local_expectation`, which raised ``ValueError`` because the contracted ``Dense1D`` view was not given its number of sites.
+- [`CircuitPermMPS`](quimb.tensor.circuit.CircuitPermMPS): fix `amplitude`, `to_dense` and `local_expectation` returning incorrectly-labelled qubits under a non-trivial lazy permutation (only `sample` previously inverted the permutation back to logical qubit order).
 
 - [`tensor_network_1d_compress_src`](quimb.tensor.tn1d.compress.tensor_network_1d_compress_src) and [`tensor_network_1d_compress_srcmps`](quimb.tensor.tn1d.compress.tensor_network_1d_compress_srcmps): call [`enforce_1d_like`](quimb.tensor.tn1d.compress.enforce_1d_like) like the other 1D compression methods, fixing compression of tensor networks with long range (site skipping) bonds, e.g. from lazily applied long range gates.
 - [`enforce_1d_like`](quimb.tensor.tn1d.compress.enforce_1d_like): fix the identity string insertion for long range bonds when the supplied ``site_tags`` order the two tensors in reverse (e.g. with ``sweep_reverse=True``), which previously wired the identities to the wrong sites.

--- a/quimb/tensor/circuit.py
+++ b/quimb/tensor/circuit.py
@@ -1890,6 +1890,38 @@ def _apply_controlled_gate_htn(
     )
 
 
+def _apply_controlled_gate_eager(psi, gate, tags=None, **gate_opts):
+    """Apply a multi-controlled gate to a state whose gates are eagerly
+    contracted (e.g. a dense statevector): insert the low-rank HTN
+    representation of the gate, then contract the resulting tensor network
+    back into the dense state. This avoids ever forming the full ``2**(2N)``
+    dense operator.
+    """
+    all_qubits = (*gate.controls, *gate.qubits)
+    ntotal = len(all_qubits)
+    upper_inds = [rand_uuid() for _ in range(ntotal)]
+    lower_inds = [rand_uuid() for _ in range(ntotal)]
+
+    htn = build_controlled_gate_htn(
+        len(gate.controls),
+        gate,
+        upper_inds=upper_inds,
+        lower_inds=lower_inds,
+        tags_each=[psi.site_tag(i) for i in all_qubits],
+        tags_all=tags,
+    )
+    psi.gate_inds_with_tn_(
+        inds=[psi.site_ind(i) for i in all_qubits],
+        gate=htn,
+        gate_inds_inner=lower_inds,
+        gate_inds_outer=upper_inds,
+    )
+    # contract the whole state back to one tensor; strictly only the acted-on
+    # sites' region needs contracting, but that requires carefully specifying
+    # output_inds (the HTN hyper-index plus bonds to the rest of the state)
+    psi.contract_(output_inds=tuple(psi.outer_inds()))
+
+
 def apply_controlled_gate(
     psi,
     gate,
@@ -1900,13 +1932,13 @@ def apply_controlled_gate(
 ):
     if contract in ("auto-mps", "nonlocal"):
         _apply_controlled_gate_mps(psi, gate, tags=tags, **gate_opts)
-    elif contract in (
-        "auto-split-gate",
-        "split-gate",
-    ):
+    elif contract in ("auto-split-gate", "split-gate"):
         _apply_controlled_gate_htn(
             psi, gate, tags=tags, propagate_tags=propagate_tags, **gate_opts
         )
+    elif contract is True:
+        # eagerly contracted dense state: form HTN gate and contract it in
+        _apply_controlled_gate_eager(psi, gate, tags=tags, **gate_opts)
     else:
         raise ValueError(
             f"Contract method '{contract}' not "
@@ -6023,6 +6055,49 @@ class CircuitPermMPS(CircuitMPS):
 
         return psi
 
+    def to_dense(
+        self, reverse=False, optimize="auto-hq", backend=None, dtype=None
+    ):
+        # contract the qubit-relabeled MPS directly (`self.psi` already maps
+        # `site_ind(i)` to logical qubit `i`); no exact-TN simplification
+        psi = self.psi
+        self._maybe_convert(psi, dtype)
+        output_inds = tuple(map(psi.site_ind, range(self.N)))
+        if reverse:
+            output_inds = output_inds[::-1]
+        t = psi.contract(
+            all, output_inds=output_inds, optimize=optimize, backend=backend
+        )
+        k = ops.reshape(t.data, (-1, 1))
+        if isinstance(k, np.ndarray):
+            k = qu.qarray(k)
+        return k
+
+    def amplitude(self, b, optimize="auto-hq", backend=None, dtype=None):
+        if len(b) != self.N:
+            raise ValueError(
+                f"Bit-string {b} length does not "
+                f"match number of qubits {self.N}."
+            )
+        # project each physical index onto its bitstring value first, then
+        # contract the resulting scalar network (cheap single-layer amplitude)
+        psi = self.psi
+        self._maybe_convert(psi, dtype)
+        for i, x in zip(range(self.N), b):
+            psi.isel_({psi.site_ind(i): int(x)})
+        return psi.contract(
+            all, output_inds=(), optimize=optimize, backend=backend
+        )
+
+    def local_expectation(self, G, where, *args, **kwargs):
+        # translate logical qubit(s) to their current physical site(s), since
+        # the underlying MPS is stored in permuted (physical) order
+        if isinstance(where, numbers.Integral):
+            where = self.qubits.index(where)
+        else:
+            where = tuple(self.qubits.index(w) for w in where)
+        return super().local_expectation(G, where, *args, **kwargs)
+
 
 class CircuitDense(Circuit):
     """Quantum circuit simulation keeping the state in full dense form."""
@@ -6046,7 +6121,7 @@ class CircuitDense(Circuit):
     def psi(self):
         t = self._psi ^ ...
         psi = t.as_network()
-        psi.view_as_(Dense1D, like=self._psi)
+        psi.view_as_(Dense1D, like=self._psi, L=self.N)
         return psi
 
     @property

--- a/tests/test_tensor/test_circuit/test_cross_backend.py
+++ b/tests/test_tensor/test_circuit/test_cross_backend.py
@@ -1,0 +1,102 @@
+"""Unified (same input and final call) circuit tests for making sure
+all effectively exact simulators match.
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import quimb as qu
+import quimb.tensor as qtn
+
+# exact (or effectively-exact at this size/shallow depth) simulators
+EXACT_SIMS = [
+    qtn.Circuit,
+    qtn.CircuitDense,
+    qtn.CircuitMPS,
+    qtn.CircuitMPSLazy,
+    qtn.CircuitPermMPS,
+]
+SIM_IDS = [S.__name__ for S in EXACT_SIMS]
+N = 6
+BITSTRINGS = ["0" * N, "1" * N, "010101", "110010"]
+
+
+def get_gates_ref():
+    """A fixed, deterministic, low-entanglement circuit with 1q, 2q,
+    parametrized, controlled and long-range gates, shallow enough to stay
+    exact for the MPS representations at default truncation. The long-range
+    gates induce a non-trivial qubit permutation in ``CircuitPermMPS``."""
+    rng = np.random.default_rng(1234)
+    one_q = ["RX", "RY", "RZ"]
+    gs = [("H", i) for i in range(N)]
+    for layer in range(3):
+        for i in range(layer % 2, N - 1, 2):
+            gs.append(("CX", i, i + 1))
+        for i in range(N):
+            gs.append(
+                (one_q[(i + layer) % 3], float(rng.uniform(0, 2 * np.pi)), i)
+            )
+    gs.append(("RZZ", 0.5, 0, 1))
+    gs.append(("CZ", 2, 3))
+    # long-range (non-adjacent) gates
+    gs.append(("CX", 0, 4))
+    gs.append(("RZZ", 0.3, 1, 5))
+    return gs
+
+
+@pytest.fixture(scope="module")
+def circuit_ref():
+    return qtn.Circuit.from_gates(get_gates_ref())
+
+
+@pytest.mark.parametrize("Sim", EXACT_SIMS, ids=SIM_IDS)
+def test_to_dense_matches_exact(Sim, circuit_ref):
+    c = Sim.from_gates(get_gates_ref())
+    assert_allclose(c.to_dense(), circuit_ref.to_dense(), atol=1e-10)
+
+
+@pytest.mark.parametrize("Sim", EXACT_SIMS, ids=SIM_IDS)
+def test_amplitude_matches_exact(Sim, circuit_ref):
+    c = Sim.from_gates(get_gates_ref())
+    for b in BITSTRINGS:
+        assert_allclose(c.amplitude(b), circuit_ref.amplitude(b), atol=1e-10)
+
+
+@pytest.mark.parametrize("Sim", EXACT_SIMS, ids=SIM_IDS)
+def test_local_expectation_matches_exact(Sim, circuit_ref):
+    c = Sim.from_gates(get_gates_ref())
+    Z = qu.pauli("Z")
+    for i in range(N):
+        assert_allclose(
+            c.local_expectation(Z, i),
+            circuit_ref.local_expectation(Z, i),
+            atol=1e-10,
+        )
+    ZZ = qu.pauli("Z") & qu.pauli("Z")
+    for where in [(0, 1), (0, 5)]:  # adjacent and long-range pairs
+        assert_allclose(
+            c.local_expectation(ZZ, where),
+            circuit_ref.local_expectation(ZZ, where),
+            atol=1e-10,
+        )
+
+
+@pytest.mark.parametrize("Sim", EXACT_SIMS, ids=SIM_IDS)
+def test_sample_observables_match_exact(Sim, circuit_ref):
+    """Estimate <Z_i> from samples and compare to exact, a statistical, but
+    deterministic (fixed seed) with loose tolerance, sampling check."""
+    c = Sim.from_gates(get_gates_ref())
+    n_samples = 1000
+    acc = np.zeros(N)
+    for b in c.sample(n_samples, seed=2024):
+        for i, x in enumerate(b):
+            acc[i] += 1 if int(x) == 0 else -1
+    z_emp = acc / n_samples
+    z_exact = np.array(
+        [
+            circuit_ref.local_expectation(qu.pauli("Z"), i).real
+            for i in range(N)
+        ]
+    )
+    assert_allclose(z_emp, z_exact, atol=0.15)

--- a/tests/test_tensor/test_circuit/test_exact.py
+++ b/tests/test_tensor/test_circuit/test_exact.py
@@ -29,10 +29,7 @@ def random_a2a_circ(L, depth, seed=42):
             g = rng.choice(["rx", "ry", "rz"])
             gates.append((d, g, rng.normal(1.0, 0.5), q))
 
-    circ = qtn.Circuit(L)
-    circ.apply_gates(gates)
-
-    return circ
+    return qtn.Circuit.from_gates(gates)
 
 
 def qft_circ(n, swaps=True, **circuit_opts):
@@ -492,3 +489,63 @@ class TestCircuitParams:
 
         assert circ.get_params()["theta"].dtype == np.float32
         assert circ.psi["GATE_0"].params.dtype == np.float32
+
+
+class TestCircuitDense:
+    def _circ(self, Sim=qtn.CircuitDense):
+        N = 5
+        gates = [("H", i) for i in range(N)]
+        for i in range(N - 1):
+            gates.append(("CX", i, i + 1))
+        for i in range(N):
+            gates.append(("RY", 0.1 * (i + 1), i))
+        return Sim.from_gates(gates), N, gates
+
+    def test_matches_exact_statevector_and_amplitude(self):
+        cd, N, gates = self._circ()
+        ce = qtn.Circuit.from_gates(gates)
+        assert_allclose(cd.to_dense(), ce.to_dense(), atol=1e-12)
+        for b in ["0" * N, "1" * N, "01010"]:
+            assert_allclose(cd.amplitude(b), ce.amplitude(b), atol=1e-12)
+
+    def test_simulate_counts(self):
+        cd, N, _ = self._circ()
+        counts = cd.simulate_counts(512)
+        assert sum(counts.values()) == 512
+        assert all(len(b) == N for b in counts)
+
+    def test_psi_partial_trace_local_expectation_match_exact(self):
+        cd, N, gates = self._circ()
+        ce = qtn.Circuit.from_gates(gates)
+        assert_allclose(cd.psi.to_dense(), ce.psi.to_dense(), atol=1e-12)
+        assert_allclose(
+            cd.partial_trace([0, 1]), ce.partial_trace([0, 1]), atol=1e-12
+        )
+        for i in range(N):
+            assert_allclose(
+                cd.local_expectation(qu.pauli("Z"), i),
+                ce.local_expectation(qu.pauli("Z"), i),
+                atol=1e-12,
+            )
+
+    def test_uni_unsupported(self):
+        # a contracted dense state has no unitary TN to extract
+        cd, N, _ = self._circ()
+        with pytest.raises(ValueError):
+            cd.uni
+
+    def test_controlled_gates_match_exact(self):
+        # controls= gates apply by contracting the controlled operator into
+        # the dense state (single and multi control)
+        gates = [
+            ("H", 0),
+            ("RY", 0.7, 1),
+            ("RX", 0.3, 2),
+            ("RY", 0.9, 3),
+            qtn.Gate("X", params=(), qubits=(2,), controls=(0,)),
+            qtn.Gate("Z", params=(), qubits=(1,), controls=(0, 3)),
+            qtn.Gate("Y", params=(), qubits=(3,), controls=(0, 1, 2)),
+        ]
+        cd = qtn.CircuitDense.from_gates(gates)
+        ce = qtn.Circuit.from_gates(gates)
+        assert_allclose(cd.to_dense(), ce.to_dense(), atol=1e-12)

--- a/tests/test_tensor/test_circuit/test_gates.py
+++ b/tests/test_tensor/test_circuit/test_gates.py
@@ -133,7 +133,6 @@ class TestCircuitGates:
         assert qu.expec(psi, psi) == pytest.approx(1.0)
 
     def test_auto_split_gate(self):
-        n = 3
         ops = [
             ("u3", 1.0, 2.0, 3.0, 0),
             ("u3", 2.0, 3.0, 1.0, 1),
@@ -146,16 +145,19 @@ class TestCircuitGates:
             ("h", 1),
             ("h", 2),
         ]
-        cnorm = qtn.Circuit(n, gate_opts=dict(contract="split-gate"))
-        cnorm.apply_gates(ops)
+        cnorm = qtn.Circuit.from_gates(
+            ops, gate_opts=dict(contract="split-gate")
+        )
         assert cnorm.psi.max_bond() == 4
 
-        cswap = qtn.Circuit(n, gate_opts=dict(contract="swap-split-gate"))
-        cswap.apply_gates(ops)
+        cswap = qtn.Circuit.from_gates(
+            ops, gate_opts=dict(contract="swap-split-gate")
+        )
         assert cswap.psi.max_bond() == 4
 
-        cauto = qtn.Circuit(n, gate_opts=dict(contract="auto-split-gate"))
-        cauto.apply_gates(ops)
+        cauto = qtn.Circuit.from_gates(
+            ops, gate_opts=dict(contract="auto-split-gate")
+        )
         assert cauto.psi.max_bond() == 2
 
         assert qu.fidelity(
@@ -222,3 +224,29 @@ class TestCircuitGates:
         circ.apply_gate("SWAP", qubits=(N - 2, N - 1), controls=range(N - 2))
         (b,) = circ.sample(1, group_size=3, seed=42)
         assert b[N - 2] == "0"
+
+
+class TestGate:
+    def test_copy_with_is_nonmutating(self):
+        g = qtn.Gate("RX", params=(0.5,), qubits=(2,))
+        g2 = g.copy_with(qubits=(3,))
+        assert g2.qubits == (3,)
+        assert g.qubits == (2,)  # original unchanged
+        assert g2.label == "RX"
+        assert tuple(g2.params) == (0.5,)
+
+    @pytest.mark.parametrize(
+        "label, params, qubits, L",
+        [
+            ("CX", (), (0, 1), 2),
+            ("CX", (), (0, 2), 4),
+            ("RZZ", (0.7,), (1, 3), 4),
+        ],
+    )
+    def test_build_mpo_is_unitary(self, label, params, qubits, L):
+        gate = qtn.Gate(label, params=params, qubits=qubits)
+        mpo = gate.build_mpo(L=L)
+        assert isinstance(mpo, qtn.MatrixProductOperator)
+        assert mpo.L == L
+        U = mpo.to_dense()
+        assert_allclose(U @ U.conj().T, np.eye(U.shape[0]), atol=1e-10)

--- a/tests/test_tensor/test_circuit/test_mps.py
+++ b/tests/test_tensor/test_circuit/test_mps.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 import quimb as qu
 import quimb.tensor as qtn
@@ -111,12 +112,8 @@ class TestCircuitMPS:
             )
         )
 
-        circ = qtn.Circuit(N=10)
-        circ.apply_gates(gates)
-        psi_lazy = circ.psi
-        circ = qtn.CircuitMPS(N=10)
-        circ.apply_gates(gates)
-        mps = circ.psi
+        psi_lazy = qtn.Circuit.from_gates(gates).psi
+        mps = qtn.CircuitMPS.from_gates(gates).psi
         assert mps.norm() == pytest.approx(1.0)
         assert mps.distance_normalized(psi_lazy) < 1e-6
 
@@ -140,6 +137,43 @@ class TestCircuitMPS:
         samples = list(circ.sample(10, seed=1234))
         assert len(set(samples)) == 2
 
+    def _entangling_gates(self, N=10, depth=6, seed=1):
+        rng = np.random.default_rng(seed)
+        gates = [("H", i) for i in range(N)]
+        for d in range(depth):
+            for i in range(d % 2, N - 1, 2):
+                gates.append(("CX", i, i + 1))
+            for i in range(N):
+                gates.append(("RY", float(rng.uniform(0, 2 * np.pi)), i))
+        return gates
+
+    def test_max_bond_truncates_the_state(self):
+        gates = self._entangling_gates()
+        full = qtn.CircuitMPS.from_gates(gates)
+        trunc = qtn.CircuitMPS.from_gates(gates, max_bond=4)
+        assert trunc.psi.max_bond() == 4
+        assert full.psi.max_bond() > 4
+
+    def test_fidelity_and_error_estimate(self):
+        gates = self._entangling_gates()
+        full = qtn.CircuitMPS.from_gates(gates)
+        assert full.fidelity_estimate() == pytest.approx(1.0, abs=1e-10)
+        assert full.error_estimate() == pytest.approx(0.0, abs=1e-10)
+
+        trunc = qtn.CircuitMPS.from_gates(gates, max_bond=4)
+        f = trunc.fidelity_estimate()
+        assert 0.0 < f < 1.0
+        # error estimate is the complementary norm loss
+        assert trunc.error_estimate() == pytest.approx(1.0 - f, abs=1e-10)
+
+    def test_uni_unsupported(self):
+        circ = qtn.CircuitMPS(3)
+        circ.h(0)
+        with pytest.raises(ValueError):
+            circ.uni
+
+
+class TestCircuitPermMPS:
     def test_permmps_sampling(self):
         N = 6
         circ = qtn.CircuitPermMPS(N)
@@ -169,6 +203,124 @@ class TestCircuitMPS:
         assert circ.qubits == [0, 3, 1, 2]
         assert set(circ.sample(10, seed=42)) == {"0100"}
 
+    def _permuting_circuit(self):
+        # nonlocal 2-qubit gates make the lazy qubit permutation non-trivial
+        gates = [("H", 0), ("CX", 0, 3), ("CX", 1, 4), ("RY", 0.3, 2)]
+        return qtn.CircuitPermMPS.from_gates(gates), gates
+
+    def test_qubit_ordering_tracks_permutation(self):
+        cp, _ = self._permuting_circuit()
+        order = tuple(cp.calc_qubit_ordering())
+        assert sorted(order) == list(range(5))  # a genuine permutation
+        assert order != tuple(range(5))  # and a non-trivial one
+
+    def test_get_psi_unordered_is_raw_mps(self):
+        cp, _ = self._permuting_circuit()
+        raw = cp.get_psi_unordered()
+        assert isinstance(raw, qtn.MatrixProductState)
+        # the public psi is a general tensor network, not an MPS
+        assert not isinstance(cp.psi, qtn.MatrixProductState)
+
+    def test_adjacent_su4_matches_exact(self):
+        # an adjacent 2q gate induces no permutation, so psi/to_dense are correct
+        rng = np.random.default_rng(7)
+        su4 = tuple(rng.uniform(0, 2 * np.pi, 15))
+        gates = [("H", 0), ("H", 1), ("SU4", *su4, 0, 1)]
+        # qubit 2 is idle, so pass N explicitly (from_gates would infer N=2)
+        cp = qtn.CircuitPermMPS.from_gates(gates, N=3)
+        ce = qtn.Circuit.from_gates(gates, N=3)
+        assert tuple(cp.qubits) == (0, 1, 2)  # no permutation induced
+        assert abs(qu.fidelity(cp.to_dense(), ce.to_dense())) == pytest.approx(
+            1.0, abs=1e-10
+        )
+
+    def test_sample_correct_under_permutation(self):
+        # sample() inverts the lazy permutation back to logical order
+        # logical state is (|000> + |101>)/√2
+        cp = qtn.CircuitPermMPS.from_gates([("H", 0), ("CX", 0, 2)])
+        assert tuple(cp.qubits) != (0, 1, 2)
+        assert set(cp.sample(50, seed=1)) == {"000", "101"}
+
+    def test_controlled_gate_via_controls_kwarg_unsupported(self):
+        # controlled gates (controls=) are unsupported under the swap+split path
+        cp = qtn.CircuitPermMPS(3)
+        cp.h(0)
+        with pytest.raises(ValueError):
+            cp.apply_gate("X", 2, controls=(0,))
+
+    def test_amplitude_to_dense_correct_under_permutation(self):
+        # the lazy permutation is relabelled back to logical order for the
+        # exact-contraction entry points: H(0);CX(0,2) is (|000> + |101>)/√2
+        cp = qtn.CircuitPermMPS.from_gates([("H", 0), ("CX", 0, 2)])
+        ce = qtn.Circuit.from_gates([("H", 0), ("CX", 0, 2)])
+        assert tuple(cp.qubits) != (0, 1, 2)  # a non-trivial permutation
+        assert cp.amplitude("101") == pytest.approx(ce.amplitude("101"))
+        assert cp.amplitude("110") == pytest.approx(0.0)
+        assert abs(qu.fidelity(cp.to_dense(), ce.to_dense())) == pytest.approx(
+            1.0, abs=1e-10
+        )
+
+    def test_observables_correct_under_3cycle_permutation(self):
+        # a genuine 3-cycle (not self-inverse) with non-symmetric amplitudes:
+        # distinguishes "permutation applied" from "applied twice / not at all"
+        N = 4
+        gates = [
+            ("RY", 0.7, 0),
+            ("RY", 1.1, 1),
+            ("RY", 0.3, 2),
+            ("RY", 0.5, 3),
+            ("CX", 0, 2),
+            ("CX", 0, 3),
+            ("CX", 1, 3),
+        ]
+        cp = qtn.CircuitPermMPS.from_gates(gates)
+        ce = qtn.Circuit.from_gates(gates)
+        order = tuple(cp.qubits)
+        inverse = [0] * N
+        for site, logical in enumerate(order):
+            inverse[logical] = site
+        # genuine 3-cycle: not identity, and not self-inverse (transposition)
+        assert order not in (tuple(range(N)), tuple(inverse))
+
+        assert_allclose(cp.to_dense(), ce.to_dense(), atol=1e-10)
+        for i in range(2**N):
+            b = f"{i:0{N}b}"
+            assert cp.amplitude(b) == pytest.approx(ce.amplitude(b), abs=1e-10)
+        assert_allclose(
+            cp.partial_trace([0, 1]), ce.partial_trace([0, 1]), atol=1e-10
+        )
+        for i in range(N):
+            assert cp.local_expectation(qu.pauli("Z"), i) == pytest.approx(
+                ce.local_expectation(qu.pauli("Z"), i)
+            )
+
+    def test_long_range_local_expectation_under_permutation(self):
+        # a 2-site observable whose logical qubits land on non-adjacent
+        # *physical* sites after the lazy permutation
+        N = 6
+        gates = [
+            ("H", 0),
+            ("RY", 0.7, 1),
+            ("RY", 1.1, 2),
+            ("RY", 0.3, 3),
+            ("RY", 0.9, 4),
+            ("RY", 0.5, 5),
+            ("CX", 0, 2),
+            ("CX", 1, 4),
+            ("CZ", 0, 5),
+            ("RZZ", 0.4, 2, 5),
+        ]
+        cp = qtn.CircuitPermMPS.from_gates(gates)
+        ce = qtn.Circuit.from_gates(gates)
+        assert tuple(cp.qubits) != tuple(range(N))  # non-trivial permutation
+        ZZ = qu.pauli("Z") & qu.pauli("Z")
+        for where in [(0, 5), (1, 4), (0, 3)]:
+            assert cp.local_expectation(ZZ, where) == pytest.approx(
+                ce.local_expectation(ZZ, where), abs=1e-10
+            )
+
+
+class TestCircuitMPSLazy:
     def test_lazymps_sampling(self):
         N = 6
         circ = qtn.CircuitMPSLazy(N)
@@ -315,8 +467,7 @@ class TestCircuitMPS:
             9: 1,
         }
 
-        checker = qtn.Circuit(N=10)
-        checker.apply_gates(circ.gates)
+        checker = qtn.Circuit.from_gates(circ.gates)
 
         assert circ.psi.norm() == pytest.approx(1.0)
         assert circ.psi.distance_normalized(checker.psi) < 1e-6
@@ -337,9 +488,7 @@ class TestCircuitMPS:
         circ.apply_gates(gates)
         lazy_state = circ.psi
 
-        circ = qtn.Circuit(N)
-        circ.apply_gates(gates)
-        dense_state = circ.psi
+        dense_state = qtn.Circuit.from_gates(gates).psi
 
         fidelity = np.abs(lazy_state.H @ dense_state) ** 2
 
@@ -367,9 +516,7 @@ class TestCircuitMPS:
         circ.apply_gates(gates)
         lazy_state = circ.psi
 
-        circ = qtn.Circuit(N)
-        circ.apply_gates(gates)
-        dense_state = circ.psi
+        dense_state = qtn.Circuit.from_gates(gates).psi
 
         if method in {"src"}:
             baseline = 0.95
@@ -383,3 +530,53 @@ class TestCircuitMPS:
         assert fidelity >= baseline, (
             f"Fidelity too low for N={N}, method={method}"
         )
+
+    def test_single_qubit_gates_stay_eager(self):
+        circ = qtn.CircuitMPSLazy(4)
+        for i in range(4):
+            circ.h(i)
+            circ.rx(0.3, i)
+        # eager 1q gates leave nothing pending and never grow a bond
+        assert dict(circ._uncompressed_sites) == {}
+        assert circ.psi.max_bond() == 1
+
+    def test_two_qubit_gates_deferred_until_flush(self):
+        circ = qtn.CircuitMPSLazy(4, max_bond=8, compress_every=10)
+        for i in range(3):
+            circ.cx(i, i + 1)
+        # pending, not yet compressed
+        assert dict(circ._uncompressed_sites)
+
+        n_calls = {"n": 0}
+        orig = circ._compress
+
+        def counted():
+            n_calls["n"] += 1
+            return orig()
+
+        circ._compress = counted
+        _ = circ.psi  # a state access flushes exactly once
+        assert n_calls["n"] == 1
+        assert dict(circ._uncompressed_sites) == {}
+
+    def test_special_gates_match_exact(self):
+        gates = [("H", 0), ("H", 1), ("CX", 0, 1), ("SWAP", 1, 2), ("IDEN", 0)]
+        ce = qtn.Circuit.from_gates(gates)
+        cl = qtn.CircuitMPSLazy.from_gates(gates)
+        assert abs(qu.fidelity(cl.to_dense(), ce.to_dense())) == pytest.approx(
+            1.0, abs=1e-10
+        )
+
+    def test_property_setters_sync(self):
+        circ = qtn.CircuitMPSLazy(3)
+        circ.max_bond = 16
+        circ.cutoff = 1e-9
+        circ.method = "dm"
+        assert circ.max_bond == 16
+        assert circ.cutoff == 1e-9
+        assert circ.method == "dm"
+        # both the per-flush compress opts and the gate-application opts track
+        assert circ.gate_opts["max_bond"] == 16
+        assert circ.compress_opts["max_bond"] == 16
+        assert circ.compress_opts["cutoff"] == 1e-9
+        assert circ.compress_opts["method"] == "dm"


### PR DESCRIPTION
- CircuitDense: pass L to the Dense1D view so psi/partial_trace/local_expectation work instead of raising
- CircuitPermMPS: native to_dense/amplitude + logical→physical where translation, so observables respect the lazy permutation (only sample did before)
- CircuitDense: support controls= via low-rank HTN insert-and-contract
- add cross-backend equivalence tests + CircuitDense/PermMPS/Gate coverage