### PR TITLE
circuit: fix lazy MPS state access and copy handling

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,9 @@ Release notes for `quimb`.
 
 - [`CircuitDense`](#CircuitDense): fix `psi`, `partial_trace` and `local_expectation`, which raised ``ValueError`` because the contracted ``Dense1D`` view was not given its number of sites.
 - [`CircuitPermMPS`](#CircuitPermMPS): fix `amplitude`, `to_dense` and `local_expectation` returning incorrectly-labelled qubits under a non-trivial lazy permutation (only `sample` previously inverted the permutation back to logical qubit order).
+- [`CircuitPermMPS`](#CircuitPermMPS) and [`CircuitMPSLazy`](#CircuitMPSLazy): fix `copy()`, which returned unusable copies missing the subclass attributes such as the qubit ordering and the lazy compression bookkeeping ({issue}`387`).
+- [`CircuitMPSLazy`](#CircuitMPSLazy): flush pending lazy gates in all inherited state accessors (`to_dense`, `amplitude`, `partial_trace`, `compute_marginal`, ...), which previously returned the exact state, bypassing the configured compression, and invalidate cached simplified states when a compression mutates the state, so results no longer depend on accessor order ({issue}`387`).
+- [`CircuitMPSLazy`](#CircuitMPSLazy): raise `NotImplementedError` for `schrodinger_contract`, which is not defined for the approximate lazy MPS simulator and previously failed with an internal `IndexError` ({issue}`387`).
 
 - [`tensor_network_1d_compress_src`](#tensor_network_1d_compress_src) and [`tensor_network_1d_compress_srcmps`](#tensor_network_1d_compress_srcmps): call [`enforce_1d_like`](#enforce_1d_like) like the other 1D compression methods, fixing compression of tensor networks with long range (site skipping) bonds, e.g. from lazily applied long range gates.
 - [`enforce_1d_like`](#enforce_1d_like): fix the identity string insertion for long range bonds when the supplied ``site_tags`` order the two tensors in reverse (e.g. with ``sweep_reverse=True``), which previously wired the identities to the wrong sites.

--- a/quimb/tensor/circuit/mps.py
+++ b/quimb/tensor/circuit/mps.py
@@ -353,6 +353,12 @@ class CircuitPermMPS(CircuitMPS):
         # keep track of the current qubit ordering
         self.qubits = list(range(self.N))
 
+    def copy(self):
+        """Copy the circuit and its state."""
+        new = super().copy()
+        new.qubits = list(self.qubits)
+        return new
+
     def _apply_gate(self, gate, tags=None, **gate_opts):
         # first translate gate qubits to their current 'physical' location
         qubits = gate.qubits
@@ -627,6 +633,14 @@ class CircuitMPSLazy(CircuitMPS):
     def method(self, value):
         self.compress_opts["method"] = value
 
+    def copy(self):
+        """Copy the circuit and its state."""
+        new = super().copy()
+        new.compress_opts = dict(self.compress_opts)
+        new._uncompressed_sites = dict(self._uncompressed_sites)
+        new.compress_every = self.compress_every
+        return new
+
     def _compress(self):
         """Compress the current state by contracting in all gates and then applying
         the specified compression method via
@@ -652,6 +666,10 @@ class CircuitMPSLazy(CircuitMPS):
             self.gate_opts["info"]["cur_orthog"] = (0, 0)
 
         self._uncompressed_sites.clear()
+
+        # compression mutates `_psi` in place, so any cached simplified
+        # representations of the pre-compression state are now stale
+        self.clear_storage()
 
     def _apply_gate(self, gate, tags=None, **gate_opts):
         gate_qubits = gate.qubits
@@ -685,6 +703,19 @@ class CircuitMPSLazy(CircuitMPS):
         self._compress()
         return super().psi
 
+    # all inherited state accessors (`to_dense`, `amplitude`,
+    # `partial_trace`, `compute_marginal`, `sample_chaotic`, ...) funnel
+    # through one of the following two methods, so flushing pending lazy
+    # gates here keeps them consistent with the compressed state
+
+    def get_psi_simplified(self, *args, **kwargs):
+        self._compress()
+        return super().get_psi_simplified(*args, **kwargs)
+
+    def get_rdm_lightcone_simplified(self, *args, **kwargs):
+        self._compress()
+        return super().get_rdm_lightcone_simplified(*args, **kwargs)
+
     def sample(self, C, *args, **kwargs):
         self._compress()
         yield from super().sample(C, *args, **kwargs)
@@ -696,3 +727,10 @@ class CircuitMPSLazy(CircuitMPS):
     def fidelity_estimate(self):
         self._compress()
         return super().fidelity_estimate()
+
+    def schrodinger_contract(self, *args, **contract_opts):
+        raise NotImplementedError(
+            "'Schrodinger' contraction is not defined for the approximate "
+            "lazy MPS simulator, use e.g. `psi`, `to_dense`, `amplitude`, "
+            "`sample` or `local_expectation` instead."
+        )

--- a/tests/test_tensor/test_circuit/test_mps.py
+++ b/tests/test_tensor/test_circuit/test_mps.py
@@ -319,6 +319,22 @@ class TestCircuitPermMPS:
                 ce.local_expectation(ZZ, where), abs=1e-10
             )
 
+    def test_copy_preserves_qubit_permutation(self):
+        gates = [("H", 0), ("CX", 0, 3), ("RY", 0.3, 2)]
+        circ = qtn.CircuitPermMPS.from_gates(gates)
+        assert tuple(circ.qubits) != tuple(range(4))
+
+        copied = circ.copy()
+        assert copied.qubits == circ.qubits
+        assert copied.qubits is not circ.qubits
+        assert copied.psi.distance_normalized(circ.psi) < 1e-6
+
+        # further gates on the copy leave the original untouched
+        qubits_before = list(circ.qubits)
+        copied.cx(1, 2)
+        assert circ.qubits == qubits_before
+        assert circ.num_gates == len(gates)
+
 
 class TestCircuitMPSLazy:
     def test_lazymps_sampling(self):
@@ -580,3 +596,94 @@ class TestCircuitMPSLazy:
         assert circ.compress_opts["max_bond"] == 16
         assert circ.compress_opts["cutoff"] == 1e-9
         assert circ.compress_opts["method"] == "dm"
+
+    def test_copy_with_pending_gates(self):
+        circ = qtn.CircuitMPSLazy(4, max_bond=8, compress_every=4)
+        circ.h(0)
+        circ.cx(0, 3)
+        assert dict(circ._uncompressed_sites)
+
+        copied = circ.copy()
+        assert copied.compress_every == circ.compress_every
+        assert copied.compress_opts == circ.compress_opts
+        assert copied.compress_opts is not circ.compress_opts
+        assert copied._uncompressed_sites == circ._uncompressed_sites
+        assert copied._uncompressed_sites is not circ._uncompressed_sites
+
+        # the copy represents the same state ...
+        psi_orig = circ.psi
+        assert copied.psi.distance_normalized(psi_orig) < 1e-6
+
+        # ... and is independent of the original
+        copied.x(1)
+        assert circ.num_gates == 2
+        assert circ.psi.distance_normalized(psi_orig) < 1e-6
+
+    @staticmethod
+    def _pending_truncating_ghz():
+        # an exact GHZ state is not representable at bond dimension 1, so the
+        # configured compression visibly truncates (discarding half the
+        # norm), distinguishing the pending exact TN from the compressed MPS
+        circ = qtn.CircuitMPSLazy(
+            6, max_bond=1, cutoff=0.0, method="dm", compress_every=100
+        )
+        circ.h(0)
+        for i in range(5):
+            circ.cx(i, i + 1)
+        assert dict(circ._uncompressed_sites)
+        return circ
+
+    def test_to_dense_flushes_and_matches_psi(self):
+        circ = self._pending_truncating_ghz()
+        dense = np.asarray(circ.to_dense()).reshape(-1)
+        assert not circ._uncompressed_sites
+        k = np.asarray(circ.psi.to_dense()).reshape(-1)
+        assert_allclose(dense, k, atol=1e-10)
+        assert np.linalg.norm(dense) ** 2 == pytest.approx(0.5)
+
+    def test_amplitude_flushes_and_matches_psi(self):
+        circ = self._pending_truncating_ghz()
+        amp = circ.amplitude("1" * 6)
+        assert not circ._uncompressed_sites
+        k = np.asarray(circ.psi.to_dense()).reshape(-1)
+        assert amp == pytest.approx(complex(k[-1]), abs=1e-10)
+
+    def test_partial_trace_flushes_and_matches_psi(self):
+        circ = self._pending_truncating_ghz()
+        rho = np.asarray(circ.partial_trace((0,)))
+        assert not circ._uncompressed_sites
+        kk = np.asarray(circ.psi.to_dense()).reshape(2, 32)
+        assert_allclose(rho, kk @ kk.conj().T, atol=1e-10)
+
+    def test_compute_marginal_flushes_and_matches_psi(self):
+        circ = self._pending_truncating_ghz()
+        marginal = np.asarray(circ.compute_marginal((0,))).reshape(-1)
+        assert not circ._uncompressed_sites
+        k = np.asarray(circ.psi.to_dense()).reshape(2, 32)
+        assert_allclose(marginal, (np.abs(k) ** 2).sum(axis=1), atol=1e-10)
+
+    def test_accessor_order_independence(self):
+        # the sequence from issue #387: to_dense before and after accessing
+        # psi must describe the same (compressed) state
+        circ = self._pending_truncating_ghz()
+        dense_before = np.asarray(circ.to_dense()).reshape(-1)
+        k = np.asarray(circ.psi.to_dense()).reshape(-1)
+        dense_after = np.asarray(circ.to_dense()).reshape(-1)
+        assert_allclose(dense_before, k, atol=1e-10)
+        assert_allclose(dense_after, k, atol=1e-10)
+
+    def test_compress_clears_cached_simplified_state(self):
+        circ = qtn.CircuitMPSLazy(4, max_bond=2)
+        circ.h(0)
+        circ.cx(0, 3)
+        # a cached simplified state from before the compression is stale
+        circ._storage[("psi_simplified", "R", 1e-12)] = circ._psi.copy()
+        circ._compress()
+        assert circ._storage == {}
+
+    def test_schrodinger_contract_raises(self):
+        circ = qtn.CircuitMPSLazy(3, max_bond=2)
+        circ.h(0)
+        circ.cx(0, 2)
+        with pytest.raises(NotImplementedError):
+            circ.schrodinger_contract()


### PR DESCRIPTION
Fixes #387 

addressing all three reported behaviours plus one closely related bug found while re-verifying on current `main`.

1. **`copy()` returned unusable copies**: `Circuit.copy()` only initializes base-class attributes. `CircuitMPSLazy` copies were missing `compress_opts`, `_uncompressed_sites` and `compress_every`, and (new find) `CircuitPermMPS` copies were missing the `qubits` ordering, both raising `AttributeError` on first state access. Fixed with small `copy()` overrides that copy the subclass attributes.

2. **Inherited state accessors bypassed the lazy compression**: `to_dense`, `amplitude`, `partial_trace`, `compute_marginal`, `sample_chaotic`, ... all funnel through `get_psi_simplified` / `get_rdm_lightcone_simplified`, which read the raw `_psi` with pending uncontracted lazy gates, returning the exact state instead of the compressed one and disagreeing with `.psi`/`sample`. `CircuitMPSLazy` now flushes pending gates in those two funnels, covering every inherited accessor in one place. Additionally, `_compress()` now clears the storage cache when it mutates `_psi` in place, so a cached pre-compression simplified state can no longer survive and results do not depend on accessor order.

3. **`schrodinger_contract` raised an internal `IndexError`**: the hardcoded contraction path is computed from the number of tensors *before* accessing `psi` triggers the lazy flush, which changes that number. Since 'Schrodinger' contraction is not defined for the approximate lazy MPS simulator anyway, it now raises `NotImplementedError` with a pointer to the supported accessors (per the earlier review guidance in #384).

Each fix comes with regression tests in `tests/test_tensor/test_circuit/test_mps.py`; the deliberately-truncating GHZ construction from the issue (exact GHZ at `max_bond=1`, which visibly discards half the norm) is used to pin the accessor-consistency semantics. Changelog updated.

Tested with the full suite:
* `pytest tests/ -q -n 16 --dist loadfile` -> `5496 passed, 347 skipped`
* `ruff check --select I ...` / `ruff format --check ...` on the changed files.

This PR was prepared with AI assistance (gpt5.5xhigh and fable5xhigh); I have reviewed and tested all changes.
The implementation and PR are submitted with human oversight; any remaining mistakes are mine.