### PR TITLE
D1BP.contract_gloop_expand, add `info` cache and `autoreduce` options

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,7 @@ Release notes for `quimb`.
 - [`TensorNetwork.norm`](#TensorNetwork.norm): add a ``strip_exponent`` option for returning the norm as a separate mantissa and log10 exponent, useful for very large or small values.
 - [`TensorNetworkGenVector.norm_gloop_expand`](#TensorNetworkGenVector.norm_gloop_expand): add a ``strip_exponent`` option, and no longer modify the supplied ``gauges`` (a copy is taken instead). Supported by a new ``strip_exponent`` option on [`TensorNetworkGen.normalize_simple`](#TensorNetworkGen.normalize_simple) for returning the normalization factor as a separate mantissa and log10 exponent, and an overall ``power`` option on [`combine_local_contractions`](#combine_local_contractions).
 - add [`Tensor.to`](#Tensor.to) and [`TensorNetwork.to`](#TensorNetwork.to) for conveniently switching backends, dtype and devices (requires autoray v0.9.0+).
+- [`D1BP.contract_gloop_expand`](#D1BP.contract_gloop_expand): caches normalized contractions and adds all singleton regions. It can also remove dangling tensors from regions. These operations do not modify the target tensor network.
 
 
 **Internal:**

--- a/quimb/tensor/belief_propagation/d1bp.py
+++ b/quimb/tensor/belief_propagation/d1bp.py
@@ -8,6 +8,8 @@ This is the simplest version of belief propagation, and is useful for
 simple investigations.
 """
 
+import itertools
+
 import autoray as ar
 
 from quimb.tensor import Tensor, TensorNetwork, rand_uuid
@@ -260,6 +262,38 @@ class D1BP(BeliefPropagationCommon):
                 self.sign = tsgn * self.sign
                 self.exponent = tlog + self.exponent
 
+    def get_normalized_tn(self):
+        """Get a normalized copy of the target tensor network.
+
+        This method rescales each tensor so its local BP contraction is one.
+        It uses the current messages. It returns the normalization scale
+        separately. It does not modify the target network, the messages, or
+        the scale in this instance.
+
+        Returns
+        -------
+        tn : TensorNetwork
+            The normalized copy of the target tensor network.
+        sign : scalar
+            The phase or sign of the normalization scale.
+        exponent : float
+            The base-10 exponent of the normalization scale.
+        """
+        tn = self.tn.copy()
+        tn.exponent = 0.0
+        sign = self.sign
+        exponent = self.exponent
+
+        for tid, t in tn.tensor_map.items():
+            tval = self.local_tensor_contract(tid)
+            tabs = ar.do("abs", tval)
+            tsgn = tval / tabs
+            t /= tsgn * tabs
+            sign = tsgn * sign
+            exponent = ar.do("log10", tabs) + exponent
+
+        return tn, sign, exponent
+
     def get_gauged_tn(self):
         """Gauge the original TN by inserting the BP-approximated transfer
         matrix eigenvectors, which may be complex. The BP-contraction of this
@@ -282,7 +316,7 @@ class D1BP(BeliefPropagationCommon):
             tng._insert_gauge_tids(U, tida, tidb, Uinv)
         return tng
 
-    def get_cluster(self, tids):
+    def get_cluster(self, tids, tn=None):
         """Get the region of tensors given by `tids`, with the messages
         on the border contracted in, removing those dangling indices.
 
@@ -290,13 +324,19 @@ class D1BP(BeliefPropagationCommon):
         ----------
         tids : sequence of int
             The tensor ids forming a region.
+        tn : TensorNetwork, optional
+            The tensor network from which to select the region. The boundary
+            messages always come from this D1BP instance.
 
         Returns
         -------
         TensorNetwork
         """
+        if tn is None:
+            tn = self.tn
+
         # take copy as we are going contract messages in
-        tnr = self.tn._select_tids(tids, virtual=False)
+        tnr = tn._select_tids(tids, virtual=False)
         oixr = tnr.outer_inds()
         for ix in oixr:
             # get the tensor this index belongs to
@@ -507,15 +547,55 @@ class D1BP(BeliefPropagationCommon):
         self,
         gloops=None,
         autocomplete=True,
+        autoreduce=True,
         strip_exponent=False,
         check_zero=True,
         optimize="auto-hq",
         combine="prod",
+        info=None,
+        progbar=False,
         **contract_opts,
     ):
         """Contract the tensor network using generalized loop cluster
         expansion.
+
+        Parameters
+        ----------
+        gloops : int or iterable of tuples, optional
+            The generalized loops to use, or an integer to automatically
+            generate all loops up to that size.
+        autocomplete : bool, optional
+            Whether to add intersecting regions required to complete the
+            region graph.
+        autoreduce : bool, optional
+            Whether to remove dangling tensors from each region. Use this
+            option only at a BP fixed point.
+        strip_exponent : bool, optional
+            Whether to return the mantissa and base-10 exponent separately.
+        check_zero : bool, optional
+            Whether to return zero early when combining a product containing
+            a zero contraction.
+        optimize : str or PathOptimizer, optional
+            The contraction path optimizer to use.
+        combine : {'prod', 'sum'}, optional
+            Whether to combine region contractions as a product or sum.
+        info : dict, optional
+            A cache for normalized scalar contractions and the tensor-neighbor
+            map. Reuse it only while the tensor network and BP messages remain
+            unchanged.
+        progbar : bool, optional
+            Whether to show a progress bar.
+        contract_opts
+            These options configure :meth:`TensorNetwork.contract`.
+
+        Returns
+        -------
+        scalar or (scalar, float)
+            The generalized loop expansion estimate. The method can return
+            the base-10 exponent separately.
         """
+        from quimb.tensor.tnag.core import gloop_remove_dangling
+
         from .regions import gen_region_counts
 
         if isinstance(gloops, int):
@@ -529,32 +609,67 @@ class D1BP(BeliefPropagationCommon):
         else:
             gloops = tuple(gloops)
 
-        if combine == "sum":
-            # make sure each contraction has the same BP-scaled environment
-            self.normalize_message_pairs()
-            self.normalize_tensors()
+        # normalize boundary overlaps and local tensor contractions to one
+        self.normalize_message_pairs()
+        tn, sign, exponent = self.get_normalized_tn()
+
+        if info is None:
+            info = {}
+        contractions = info.setdefault("contractions", {})
+
+        if autoreduce:
+            try:
+                neighbors = info["neighbors"]
+            except KeyError:
+                neighbors = info["neighbors"] = self.tn.get_tid_neighbor_map()
+        else:
+            neighbors = None
+
+        region_counts = gen_region_counts(
+            itertools.chain(gloops, ((tid,) for tid in self.tn.tensor_map)),
+            autocomplete=autocomplete,
+        )
+
+        if progbar:
+            import tqdm
+
+            region_counts = tqdm.tqdm(region_counts)
 
         zvals = []
-        for r, c in gen_region_counts(gloops, autocomplete=autocomplete):
-            # XXX: autoreduce intersecting clusters to gloops?
-            tnr = self.get_cluster(r)
-            zr = tnr.contract(optimize=optimize, **contract_opts)
+        for region, counting_factor in region_counts:
+            if autoreduce:
+                region = gloop_remove_dangling(region, neighbors)
+            else:
+                region = frozenset(region)
 
-            zvals.append((zr, c))
+            if len(region) <= 1:
+                # region has been trivially reduced to normalized local BP
+                if combine == "sum":
+                    zvals.append((1.0, counting_factor))
+                continue
+
+            try:
+                zr = contractions[region]
+            except KeyError:
+                tnr = self.get_cluster(region, tn=tn)
+                zr = tnr.contract(optimize=optimize, **contract_opts)
+                contractions[region] = zr
+
+            zvals.append((zr, counting_factor))
 
         if combine == "sum":
-            mantissa = self.sign * sum(zr * cr for zr, cr in zvals)
+            mantissa = sign * sum(zr * cr for zr, cr in zvals)
             if strip_exponent:
-                return mantissa, self.exponent
-            return mantissa * 10**self.exponent
+                return mantissa, exponent
+            return mantissa * 10**exponent
 
         return combine_local_contractions(
             zvals,
             backend=self.backend,
             strip_exponent=strip_exponent,
             check_zero=check_zero,
-            mantissa=self.sign,
-            exponent=self.exponent,
+            mantissa=sign,
+            exponent=exponent,
         )
 
 

--- a/tests/test_tensor/test_belief_propagation/test_d1bp.py
+++ b/tests/test_tensor/test_belief_propagation/test_d1bp.py
@@ -1,3 +1,6 @@
+from unittest import mock
+
+import numpy as np
 import pytest
 
 import quimb as qu
@@ -51,3 +54,137 @@ def test_get_gauged_tn():
     tn_gauged = bp.get_gauged_tn()
     Zg = qu.prod(array.item(0) for array in tn_gauged.arrays)
     assert Z == pytest.approx(Zg, rel=1e-1)
+
+
+def _get_gloop_bp():
+    edges = [
+        (0, 1),
+        (1, 2),
+        (2, 3),
+        (3, 0),
+        (2, 4),
+        (3, 5),
+    ]
+    tn = qtn.TN_from_edges_rand(
+        edges,
+        D=2,
+        seed=42,
+        dist="uniform",
+        loc=0.5,
+    )
+    tn.equalize_norms_(1.7)
+    bp = qbp.D1BP(tn)
+    bp.run(tol=1e-12)
+    assert bp.converged
+    return tn, bp
+
+
+class TestGloopExpand:
+    def test_get_normalized_tn_non_mutating(self):
+        _, bp = _get_gloop_bp()
+        bp.normalize_message_pairs()
+        z_bp = bp.contract()
+        arrays = {tid: t.data.copy() for tid, t in bp.tn.tensor_map.items()}
+        messages = {key: m.copy() for key, m in bp.messages.items()}
+        stored_scale = bp.sign, bp.exponent
+
+        tn_norm, sign, exponent = bp.get_normalized_tn()
+
+        assert tn_norm is not bp.tn
+        assert tn_norm.exponent == 0.0
+        assert (bp.sign, bp.exponent) == stored_scale
+        for tid, data in arrays.items():
+            assert np.array_equal(bp.tn.tensor_map[tid].data, data)
+            zr = bp.get_cluster((tid,), tn=tn_norm).contract()
+            assert zr == pytest.approx(1.0)
+        for key, message in messages.items():
+            assert np.array_equal(bp.messages[key], message)
+        assert sign * 10**exponent == pytest.approx(z_bp)
+
+    def test_singleton_completion_for_product_and_sum(self):
+        _, bp = _get_gloop_bp()
+        gloop = (0, 1, 2, 3)
+
+        for combine in ("prod", "sum"):
+            info = {}
+            z = bp.contract_gloop_expand(
+                gloops=(gloop,),
+                autoreduce=False,
+                combine=combine,
+                info=info,
+            )
+            _, sign, exponent = bp.get_normalized_tn()
+            contractions = info["contractions"]
+            assert set(contractions) == {frozenset(gloop)}
+
+            zloop = contractions[frozenset(gloop)]
+            scale = sign * 10**exponent
+            if combine == "prod":
+                expected = scale * zloop
+            else:
+                expected = scale * (zloop + 2.0)
+            assert z == pytest.approx(expected)
+
+    def test_cached_dangling_regions_and_unit_regions(self):
+        _, bp = _get_gloop_bp()
+        gloops = (
+            (0, 1, 2, 3, 4),
+            (0, 1, 2, 3, 5),
+        )
+        info = {}
+
+        with mock.patch.object(
+            bp, "get_cluster", wraps=bp.get_cluster
+        ) as get_cluster:
+            bp.contract_gloop_expand(gloops=gloops, info=info)
+            assert get_cluster.call_count == 1
+            bp.contract_gloop_expand(gloops=gloops, info=info)
+            assert get_cluster.call_count == 1
+
+        assert set(info["contractions"]) == {frozenset({0, 1, 2, 3})}
+        assert "neighbors" in info
+
+    def test_autoreduce_fixed_point_equivalence(self):
+        _, bp = _get_gloop_bp()
+        gloops = (
+            (0, 1, 2, 3, 4),
+            (0, 1, 2, 3, 5),
+        )
+        z_full = bp.contract_gloop_expand(gloops=gloops, autoreduce=False)
+        z_reduced = bp.contract_gloop_expand(gloops=gloops, autoreduce=True)
+        assert z_reduced == pytest.approx(z_full, rel=1e-11)
+
+    @pytest.mark.parametrize("gloops", [(), 0])
+    @pytest.mark.parametrize("autoreduce", [False, True])
+    def test_no_gloops_matches_bp(self, gloops, autoreduce):
+        _, bp = _get_gloop_bp()
+        z_bp = bp.contract()
+        info = {}
+        z_gloop = bp.contract_gloop_expand(
+            gloops=gloops,
+            autoreduce=autoreduce,
+            info=info,
+        )
+        assert z_gloop == pytest.approx(z_bp)
+        assert not info["contractions"]
+
+    @pytest.mark.parametrize("combine", ["prod", "sum"])
+    def test_strip_exponent_and_progress(self, combine):
+        _, bp = _get_gloop_bp()
+        kwargs = {
+            "gloops": ((0, 1, 2, 3),),
+            "autoreduce": False,
+            "combine": combine,
+            "info": {},
+        }
+
+        with mock.patch("tqdm.tqdm", side_effect=lambda x: x) as tqdm:
+            mantissa, exponent = bp.contract_gloop_expand(
+                strip_exponent=True,
+                progbar=True,
+                **kwargs,
+            )
+        tqdm.assert_called_once()
+
+        z = bp.contract_gloop_expand(strip_exponent=False, **kwargs)
+        assert z == pytest.approx(mantissa * 10**exponent)


### PR DESCRIPTION
Improve the basic (classical, non-hyper) belief propagation class D1BP when contracting with the loop cluster expansion (contract_gloop_expand):
- Add an `info` dict, that caches cluster contractions and can share them between e.g. different cluster size runs.
- Add an `autoreduce` options that automatically remoces tree-like dangling parts of clusters (generated usually by intersections of genuine generalized loops).