### PR TITLE
trace_distance: use hermitian trace norm by default as performance optimisation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,7 @@ Release notes for `quimb`.
 - [`TensorNetworkGenVector.norm_gloop_expand`](#TensorNetworkGenVector.norm_gloop_expand): add a ``strip_exponent`` option, and no longer modify the supplied ``gauges`` (a copy is taken instead). Supported by a new ``strip_exponent`` option on [`TensorNetworkGen.normalize_simple`](#TensorNetworkGen.normalize_simple) for returning the normalization factor as a separate mantissa and log10 exponent, and an overall ``power`` option on [`combine_local_contractions`](#combine_local_contractions).
 - add [`Tensor.to`](#Tensor.to) and [`TensorNetwork.to`](#TensorNetwork.to) for conveniently switching backends, dtype and devices (requires autoray v0.9.0+).
 - [`D1BP.contract_gloop_expand`](#D1BP.contract_gloop_expand): caches normalized contractions and adds all singleton regions. It can also remove dangling tensors from regions. These operations do not modify the target tensor network.
+- [`trace_distance`](#trace_distance): compute the trace norm from the absolute eigenvalues of the difference of the two states rather than its singular values, which is valid since that difference is hermitian, and faster, increasingly so with dimension. A new ``isherm=False`` option restores the previous singular value based computation.
 
 
 **Internal:**

--- a/quimb/calc.py
+++ b/quimb/calc.py
@@ -1007,7 +1007,7 @@ def quantum_discord(
 
 
 @zeroify
-def trace_distance(p1, p2):
+def trace_distance(p1, p2, isherm=True):
     r"""Trace distance between two states:
 
     .. math::
@@ -1031,6 +1031,10 @@ def trace_distance(p1, p2):
         The first state.
     p2 : ket or density operator
         The second state.
+    isherm : bool, optional
+        Whether to assume the difference of the states is hermitian, as it is
+        for any valid pair, in which case the faster eigendecomposition is
+        used for the trace norm rather than the SVD.
 
     Returns
     -------
@@ -1044,7 +1048,9 @@ def trace_distance(p1, p2):
 
     # Otherwise do full calculation
     return 0.5 * norm(
-        (p1 if p1_is_op else dop(p1)) - (p2 if p2_is_op else dop(p2)), "tr"
+        (p1 if p1_is_op else dop(p1)) - (p2 if p2_is_op else dop(p2)),
+        "tr",
+        isherm=isherm,
     )
 
 

--- a/tests/test_matrix/test_calc.py
+++ b/tests/test_matrix/test_calc.py
@@ -550,6 +550,26 @@ class TestTraceDistance:
             > 1 - 1e-10
         )
 
+    @pytest.mark.parametrize("seed", range(5))
+    def test_isherm_matches_svd(self, seed):
+        p1 = qu.rand_rho(2**3, seed=seed)
+        p2 = qu.rand_rho(2**3, seed=seed + 100)
+        assert_allclose(
+            qu.trace_distance(p1, p2, isherm=True),
+            qu.trace_distance(p1, p2, isherm=False),
+        )
+
+    def test_isherm_matches_eigenvalues(self):
+        # trace distance of commuting states is set by their eigenvalues
+        el1 = np.array([0.5, 0.3, 0.15, 0.05])
+        el2 = np.array([0.1, 0.4, 0.25, 0.25])
+        U = qu.rand_uni(4, seed=42)
+        p1 = U @ np.diag(el1) @ U.H
+        p2 = U @ np.diag(el2) @ U.H
+        assert_allclose(
+            qu.trace_distance(p1, p2), 0.5 * np.abs(el1 - el2).sum()
+        )
+
 
 class TestDecomp:
     @pytest.mark.parametrize("qtype", ["ket", "dop"])


### PR DESCRIPTION
**Summary** `trace_distance` computes `0.5 * norm(rho - sigma, "tr")`; that argument is the difference of two density operators, which is hermitian for any valid pair of states. Pass `isherm` through to norm so the trace norm is computed from the absolute eigenvalues rather than the singular values as a performance optimization.
`norm_trace_dense` already accepts `isherm` and norm forwards **kwargs. negativity already does this at quimb/calc.py:747.

**Timings**  5.47x speed-up at 2048 (median-over-repeats, 8 cores with OpenBLAS).

**LLM Disclosure:** agentic coding tools used; but fully reviewed as very minor change anyways.