### PR TITLE
Fix typos in markdown cells of Jupyter notebook

### DIFF
--- a/docs/examples/ex_tn_tensor_fitting.ipynb
+++ b/docs/examples/ex_tn_tensor_fitting.ipynb
@@ -168,7 +168,7 @@
    "id": "f0a34b16",
    "metadata": {},
    "source": [
-    "Compute the initial distance (in terms of frobeius norm):"
+    "Compute the initial distance (in terms of Frobenius norm):"
    ]
   },
   {
@@ -226,7 +226,7 @@
    "id": "49e80711",
    "metadata": {},
    "source": [
-    "Sometimes, autodiff based optimization can do better than ALS, see\n",
+    "Sometimes, autodiff-based optimization can do better than ALS, see\n",
     "[`TNOptimizer`](TNOptimizer) for more details:"
    ]
   },


### PR DESCRIPTION
Fixes typos in Jupyter notebook example.