### PR TITLE
D1BP: for sparse coo tensors, use specialized numba contraction kernels

### DIFF
--- a/quimb/tensor/belief_propagation/bp_common.py
+++ b/quimb/tensor/belief_propagation/bp_common.py
@@ -68,9 +68,10 @@ class BeliefPropagationCommon:
         contract_every=None,
         callback=None,
         inplace=False,
+        backend=None,
     ):
         self.tn = tn if inplace else tn.copy()
-        self.backend = self.tn.backend
+        self.backend = self.tn.backend if backend is None else backend
         self.dtype = self.tn.dtype
         self.sign = 1.0
         self.exponent = tn.exponent
@@ -331,7 +332,7 @@ class BeliefPropagationCommon:
                 max_mdiff = result.get("max_mdiff", float("inf"))
             else:
                 max_mdiff = result
-                result = dict()
+                result = {}
 
             self.mdiffs.append(max_mdiff)
 

--- a/quimb/tensor/belief_propagation/d1bp.py
+++ b/quimb/tensor/belief_propagation/d1bp.py
@@ -3,6 +3,7 @@
 - assumes no hyper indices, only standard bonds.
 - assumes a single ('dense') tensor per site
 - works directly on the '1-norm' i.e. scalar tensor network
+- supports sparse COO-format tensors, which have specialized numba kernels
 
 This is the simplest version of belief propagation, and is useful for
 simple investigations.
@@ -25,6 +26,12 @@ from .bp_common import (
 from .hd1bp import (
     compute_all_tensor_messages_tree,
 )
+from .sparse_ops import (
+    compute_all_tensor_messages_coo,
+    contract_tensor_messages_coo,
+    parse_coo,
+    sum_all_but_axis_coo,
+)
 
 
 def initialize_messages(tn, fill_fn=None):
@@ -39,6 +46,9 @@ def initialize_messages(tn, fill_fn=None):
             if fill_fn is not None:
                 d = t_from.ind_size(ix)
                 m = fill_fn((d,))
+            elif parse_coo(t_from.data) is not None:
+                # sparse COO tensor
+                m = sum_all_but_axis_coo(t_from.data, t_from.inds.index(ix))
             else:
                 m = array_contract(
                     arrays=(t_from.data,),
@@ -55,6 +65,9 @@ class D1BP(BeliefPropagationCommon):
     belief propagation algorithm. Allows message reuse. This version assumes no
     hyper indices (i.e. a standard tensor network). This is the simplest
     version of belief propagation.
+
+    The tensors can be sparse COO-format tensors, either from pydata-sparse or
+    scipy-sparse.
 
     Parameters
     ----------
@@ -125,6 +138,10 @@ class D1BP(BeliefPropagationCommon):
         contract_every=None,
         inplace=False,
     ):
+        # check for pydata-sparse.COO or scipy-sparse.COO tensors
+        # -> use optimized sparse array + dense message contractions if so
+        self.sparse = any(parse_coo(t.data) is not None for t in tn)
+
         super().__init__(
             tn=tn,
             damping=damping,
@@ -133,6 +150,7 @@ class D1BP(BeliefPropagationCommon):
             distance=distance,
             contract_every=contract_every,
             inplace=inplace,
+            backend="numpy" if self.sparse else None,
         )
 
         self.local_convergence = local_convergence
@@ -166,11 +184,15 @@ class D1BP(BeliefPropagationCommon):
 
         def _compute_ms(tid):
             t = self.tn.tensor_map[tid]
-            new_ms = compute_all_tensor_messages_tree(
-                t.data,
-                [self.messages[ix, tid] for ix in t.inds],
-                self.backend,
-            )
+            ms = [self.messages[ix, tid] for ix in t.inds]
+            coo = parse_coo(t.data)
+            if coo is not None:
+                # compute via optimized sparse contraction
+                new_ms = compute_all_tensor_messages_coo(coo, ms)
+            else:
+                new_ms = compute_all_tensor_messages_tree(
+                    t.data, ms, self.backend
+                )
             new_ms = [self._normalize_fn(m) for m in new_ms]
             new_ks = [self.key_pairs[ix, tid] for ix in t.inds]
 
@@ -353,10 +375,10 @@ class D1BP(BeliefPropagationCommon):
         """
         stn = self.tn._select_tids(tids, virtual=False)
 
-        for ix, tids in tuple(stn.ind_map.items()):
+        for ix, stids in tuple(stn.ind_map.items()):
             if ix in stn._inner_inds:
                 # insert inner excitation projector
-                tidl, tidr = tids
+                tidl, tidr = stids
                 ml = self.messages[ix, tidl]
                 mr = self.messages[ix, tidr]
                 # form outer product
@@ -367,7 +389,7 @@ class D1BP(BeliefPropagationCommon):
                 stn.tensor_map[tidr].gate_(pe, ix)
             else:
                 # insert boundary message
-                (tid,) = tids
+                (tid,) = stids
                 m = self.messages[ix, tid]
                 t = stn.tensor_map[tid]
                 t.vector_reduce_(ix, m)
@@ -442,6 +464,14 @@ class D1BP(BeliefPropagationCommon):
     def local_tensor_contract(self, tid):
         """Contract the messages around tensor ``tid``."""
         t = self.tn.tensor_map[tid]
+
+        coo = parse_coo(t.data)
+        if coo is not None:
+            # perform optimized sparse contraction
+            return contract_tensor_messages_coo(
+                coo, [self.messages[ix, tid] for ix in t.inds]
+            )
+
         arrays = [t.data]
         inputs = [tuple(range(t.ndim))]
         for i, ix in enumerate(t.inds):

--- a/quimb/tensor/belief_propagation/sparse_ops.py
+++ b/quimb/tensor/belief_propagation/sparse_ops.py
@@ -1,0 +1,145 @@
+"""Specialized kernels for belief propagation with sparse COO tensors and
+dense vector messages. Both ``sparse.COO`` and n-dimensional
+``scipy.sparse.coo_array`` are supported.
+"""
+
+import numpy as np
+
+from quimb.core import njit
+
+
+def parse_coo(x):
+    """Get the ``(coords, data)`` pair of a COO array, with ``coords`` as a
+    tuple of one flat coordinate array per dimension. Returns ``None`` if
+    ``x`` is not a COO array with zero fill value. Duplicate coordinates are
+    allowed, since every kernel here accumulates additively.
+    """
+    coords = getattr(x, "coords", None)
+    if (coords is None) or (getattr(x, "fill_value", 0) != 0):
+        return None
+    if not isinstance(coords, tuple):
+        # e.g. pydata/sparse stores a single (ndim, nnz) array already
+        coords = tuple(coords)
+    # numba requires all to have same layout
+    coords = tuple(np.ascontiguousarray(c) for c in coords)
+    return coords, x.data
+
+
+def to_dense(x):
+    """Convert a possibly sparse array to a dense numpy array."""
+    todense = getattr(x, "todense", None)
+    if todense is not None:
+        x = todense()
+    return np.asarray(x)
+
+
+@njit(nogil=True)  # pragma: no cover
+def _compute_all_tensor_messages_coo(coords, data, ms, out):
+    """Numba kernel that computes all outgoing messages for COO tensor."""
+    ndim = len(coords)
+    mvals = np.empty(ndim, dtype=data.dtype)
+    after = np.empty(ndim + 1, dtype=data.dtype)
+
+    for n in range(len(data)):
+        # for this n'th nnz entry, get the corresponding message values
+        for k in range(ndim):
+            mvals[k] = ms[k][coords[k][n]]
+
+        # compute prod_{k' > k} m_k'
+        after[ndim] = 1.0
+        for k in range(ndim - 1, -1, -1):
+            after[k] = after[k + 1] * mvals[k]
+
+        # finally compute array entry multiplied by all but one message values
+        before = data[n]
+        for k in range(ndim):
+            out[k][coords[k][n]] += before * after[k + 1]
+            before = before * mvals[k]
+
+
+@njit(nogil=True)  # pragma: no cover
+def _contract_all_messages_coo(coords, data, ms, out):
+    """Numba kernel that fully contracts a COO tensor with all incoming
+    messages."""
+    ndim = len(coords)
+
+    for n in range(len(data)):
+        val = data[n]
+        for k in range(ndim):
+            val = val * ms[k][coords[k][n]]
+        out[0] += val
+
+
+def _prepare_coo_ms_for_numba(coo, ms):
+    """Make sure COO format tensor and messages are ready for numba kernels."""
+    coords, data = coo
+
+    dtype = data.dtype
+    for m in ms:
+        if m.dtype != dtype:
+            dtype = np.promote_types(dtype, m.dtype)
+
+    # every message must have the same type for the kernels to index them
+    ms = tuple(np.ascontiguousarray(m, dtype=dtype) for m in ms)
+
+    return coords, np.asarray(data, dtype=dtype), ms, dtype
+
+
+def compute_all_tensor_messages_coo(coo, ms):
+    """Given messages ``ms`` incident to a sparse tensor, compute all the
+    outgoing messages, each the contraction of the tensor with every incident
+    message but one.
+
+    Parameters
+    ----------
+    coo : (tuple[array], array)
+        The ``(coords, data)`` pair, as returned by ``parse_coo``.
+    ms : sequence of array
+        The dense vector messages, one per dimension.
+
+    Returns
+    -------
+    list[array]
+    """
+    if not ms:
+        return []
+
+    coords, data, ms, dtype = _prepare_coo_ms_for_numba(coo, ms)
+    out = tuple(np.zeros(m.shape[0], dtype=dtype) for m in ms)
+    _compute_all_tensor_messages_coo(coords, data, ms, out)
+    return list(out)
+
+
+def contract_tensor_messages_coo(coo, ms):
+    """Contract a sparse tensor with a dense vector message on every
+    dimension, to a scalar.
+
+    Parameters
+    ----------
+    coo : (tuple[array], array)
+        The ``(coords, data)`` pair, as returned by ``parse_coo``.
+    ms : sequence of array
+        The dense vector messages, one per dimension.
+
+    Returns
+    -------
+    scalar
+    """
+    if not ms:
+        return coo[1].sum()
+
+    coords, data, ms, dtype = _prepare_coo_ms_for_numba(coo, ms)
+    out = np.zeros(1, dtype=dtype)
+    _contract_all_messages_coo(coords, data, ms, out)
+    return out[0]
+
+
+def sum_all_but_axis_coo(x, axis):
+    """Sum the sparse tensor ``x`` over every dimension but ``axis``, returning
+    a dense vector. This is the BP 'uniform message' initialization step.
+    """
+    other = tuple(k for k in range(x.ndim) if k != axis)
+    if not other:
+        # already 1D
+        return to_dense(x)
+    return to_dense(x.sum(axis=other))

--- a/tests/test_tensor/test_belief_propagation/test_d1bp.py
+++ b/tests/test_tensor/test_belief_propagation/test_d1bp.py
@@ -2,10 +2,16 @@ from unittest import mock
 
 import numpy as np
 import pytest
+import scipy.sparse as sps
 
 import quimb as qu
 import quimb.tensor as qtn
 import quimb.tensor.belief_propagation as qbp
+from quimb.tensor.belief_propagation.sparse_ops import (
+    compute_all_tensor_messages_coo,
+    contract_tensor_messages_coo,
+    parse_coo,
+)
 
 
 @pytest.mark.parametrize("local_convergence", [False, True])
@@ -200,3 +206,126 @@ class TestGloopExpand:
 
         z = bp.contract_gloop_expand(strip_exponent=False, **kwargs)
         assert z == pytest.approx(mantissa * 10**exponent)
+
+
+def _zero_out_half(tn, seed=42):
+    """Zero out half the entries of each tensor, always keeping the largest,
+    so that no tensor vanishes entirely.
+    """
+    rng = np.random.default_rng(seed)
+    for t in tn:
+        data = t.data.copy()
+        keep = np.argmax(np.abs(data))
+        data[rng.random(data.shape) < 0.5] = 0.0
+        data.flat[keep] = t.data.flat[keep]
+        t.modify(data=data)
+
+
+class TestSparse:
+    @pytest.mark.parametrize("shape", [(5,), (4, 6), (3, 4, 5), (2, 3, 4, 3)])
+    @pytest.mark.parametrize("dtype", ["float64", "complex128"])
+    def test_kernels_match_einsum(self, shape, dtype):
+        rng = np.random.default_rng(42)
+        x = rng.normal(size=shape)
+        ms = [rng.normal(size=d) for d in shape]
+        if dtype == "complex128":
+            x = x + 1j * rng.normal(size=shape)
+            ms = [m + 1j * rng.normal(size=m.size) for m in ms]
+        x[rng.random(shape) < 0.5] = 0.0
+        coo = parse_coo(sps.coo_array(x))
+
+        syms = "abcdefg"[: len(shape)]
+        new_ms = compute_all_tensor_messages_coo(coo, ms)
+        for k in range(len(shape)):
+            js = [j for j in range(len(shape)) if j != k]
+            eq = syms + "".join("," + syms[j] for j in js) + "->" + syms[k]
+            expected = np.einsum(eq, x, *(ms[j] for j in js))
+            assert new_ms[k] == pytest.approx(expected)
+
+        eq = syms + "".join("," + s for s in syms) + "->"
+        z = contract_tensor_messages_coo(coo, ms)
+        assert z == pytest.approx(np.einsum(eq, x, *ms))
+
+    def test_messages_promote_dtype(self):
+        rng = np.random.default_rng(42)
+        x = rng.normal(size=(3, 4))
+        x[rng.random(x.shape) < 0.5] = 0.0
+        ms = [rng.normal(size=d) + 1j * rng.normal(size=d) for d in x.shape]
+
+        new_ms = compute_all_tensor_messages_coo(
+            parse_coo(sps.coo_array(x)), ms
+        )
+        assert new_ms[0] == pytest.approx(x @ ms[1])
+        assert new_ms[1] == pytest.approx(ms[0] @ x)
+
+    def test_duplicate_coordinates_are_summed(self):
+        data = np.array([1.5, 2.5, -1.0])
+        coords = (np.array([0, 0, 1]), np.array([1, 1, 0]))
+        x = sps.coo_array((data, coords), shape=(2, 2))
+        assert not x.has_canonical_format
+        dense = np.zeros((2, 2))
+        np.add.at(dense, coords, data)
+        ms = [np.array([0.3, -0.7]), np.array([1.1, 0.5])]
+
+        new_ms = compute_all_tensor_messages_coo(parse_coo(x), ms)
+        assert new_ms[0] == pytest.approx(dense @ ms[1])
+        assert new_ms[1] == pytest.approx(ms[0] @ dense)
+
+    def test_parse_coo_only_accepts_coo(self):
+        x = np.eye(3)
+        assert parse_coo(x) is None
+        assert parse_coo(sps.csr_array(x)) is None
+        coords, data = parse_coo(sps.coo_array(x))
+        assert len(coords) == 2
+        assert data == pytest.approx(np.ones(3))
+
+    @pytest.mark.parametrize("dtype", ["float64", "complex128"])
+    def test_tree_contraction_is_exact(self, dtype):
+        tn = qtn.TN_rand_tree(20, 3, seed=42, dtype=dtype)
+        _zero_out_half(tn)
+        Z = tn.contract()
+        assert Z != 0.0
+
+        for t in tn:
+            t.modify(data=sps.coo_array(t.data))
+        assert tn.backend == "scipy"
+
+        info = {}
+        Z_bp = qbp.contract_d1bp(tn, info=info)
+        assert info["converged"]
+        assert Z_bp == pytest.approx(Z, rel=1e-10)
+
+    def test_matches_dense_messages(self):
+        tn = qtn.TN2D_from_fill_fn(
+            lambda s: qu.randn(s, dist="uniform"), 6, 6, 2
+        )
+        _zero_out_half(tn)
+
+        tn_sparse = tn.copy()
+        for t in tn_sparse:
+            t.modify(data=sps.coo_array(t.data))
+
+        bp = qbp.D1BP(tn)
+        bp_sparse = qbp.D1BP(tn_sparse)
+        # messages are dense vectors even though the tensors are not
+        assert bp_sparse.backend == "numpy"
+        for key, m in bp.messages.items():
+            assert bp_sparse.messages[key] == pytest.approx(m)
+
+        bp.run(tol=1e-12)
+        bp_sparse.run(tol=1e-12)
+        assert bp.converged
+        for key, m in bp.messages.items():
+            assert bp_sparse.messages[key] == pytest.approx(m, abs=1e-10)
+        assert bp_sparse.contract() == pytest.approx(bp.contract(), rel=1e-8)
+
+    def test_mixed_dense_and_sparse_tensors(self):
+        tn = qtn.TN_rand_tree(10, 3, seed=42)
+        Z = tn.contract()
+
+        for i, t in enumerate(tn):
+            if i % 2:
+                t.modify(data=sps.coo_array(t.data))
+
+        Z_bp = qbp.contract_d1bp(tn)
+        assert Z_bp == pytest.approx(Z, rel=1e-10)


### PR DESCRIPTION
If you supply `pydata/sparse` or `scipy.sparse.coo_array` arrays to `D1BP` (the basic belief propagation wrapper for 'classical' tensor networks with no hyperinds), then it will use specialize numba kernels to efficiently compute the message updates and contractions. This is possible becuase the messages remain 1D dense vectors.