### PR TITLE
fully fix dm and fit methods fermionic compression, extend test matrix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,7 +38,8 @@ Release notes for `quimb`.
 - [`compute_oblique_projectors`](#compute_oblique_projectors): damp inverse singular values at ``max(s) * eps`` instead of dividing by them directly. Rank-deficient environments can retain zero singular values when ``cutoff=0.0``. These values previously produced ``inf`` or ``nan`` projectors. The shared diagonal division helpers use the same damping. This also applies to [`D2BP.gauge_insert`](#D2BP.gauge_insert) with ``return_gauges="inverse"``.
 - [`safe_inverse`](#safe_inverse): compute a scalar maximum for a single vector. The previous last-axis reduction broadcast the result back. This caused a ``TypeError`` in ``mode="projector"`` boundary contractions with block-sparse backends such as ``symmray``.
 - 1D compression: fix ``sdc`` and ``sdc-oversample`` for fermionic tensor networks.
-- 1D compression: fix ``dm`` for fermionic tensor networks.
+- 1D compression: fix ``dm`` for fermionic tensor networks, including mixed bond orientations. Its eigendecomposition now keeps the same subspace as a direct SVD.
+- 1D compression: fix ``fit`` for fermionic tensor networks. Local updates now include dual-axis phases. Final conjugation now handles the total dummy-mode parity.
 - [`D2BP.compress`](#D2BP.compress) and [`D2BP.gauge_symmetric`](#D2BP.gauge_symmetric): preserve positive messages and full-rank identity matrices for fermionic tensor networks.
 - [`TensorNetwork.conj`](#TensorNetwork.conj): use ``output_inds`` to select the global output legs for fermionic conjugation phases. This also works for subnetworks.
 - [`Tensor.conj`](#Tensor.conj): add the same ``output_inds`` control for a single tensor.

--- a/pixi.lock
+++ b/pixi.lock
@@ -75,7 +75,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-6.0.3-pyh7db6752_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -84,6 +83,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/56/3b/b87da667098bb470fa30c7011b0ba351ee976dd395c78798c66e941665a3/scipy-1.18.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/74/62/b8174ca95a4cc1a7ba1520767734e016991545590b8fbde521b681701a9f/numba-0.67.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/98/07/a2c4f04e2111ccc274b4d5e3331398a9dcf6d6e5e55d6444b1ad9d6381cf/llvmlite-0.49.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -99,7 +99,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/optuna-4.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -142,6 +141,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/alembic-1.19.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/autoray-0.10.1-pyhd8ed1ab_0.conda
@@ -153,7 +153,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/optuna-4.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -197,6 +196,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/alembic-1.19.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/autoray-0.10.1-pyhd8ed1ab_0.conda
@@ -209,7 +209,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/optuna-4.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyha7b4d00_0.conda
@@ -255,6 +254,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
   docs:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -397,7 +397,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stdlib-list-0.12.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
@@ -411,6 +410,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/25/9d/2e8d27c5c012fcddef8ac4d0b79c7f791a602bab637f9a3530c65bacf865/squeaky-0.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/19/f519ef8aa2f379935a44212c5744e2b3a46173bf04e0110fb7f4af4028c9/scour-0.38.2.tar.gz
       osx-64:
@@ -501,7 +501,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stdlib-list-0.12.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
@@ -560,6 +559,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h84953be_11.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/25/9d/2e8d27c5c012fcddef8ac4d0b79c7f791a602bab637f9a3530c65bacf865/squeaky-0.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/19/f519ef8aa2f379935a44212c5744e2b3a46173bf04e0110fb7f4af4028c9/scour-0.38.2.tar.gz
       osx-arm64:
@@ -650,7 +650,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stdlib-list-0.12.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
@@ -710,6 +709,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/25/9d/2e8d27c5c012fcddef8ac4d0b79c7f791a602bab637f9a3530c65bacf865/squeaky-0.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/19/f519ef8aa2f379935a44212c5744e2b3a46173bf04e0110fb7f4af4028c9/scour-0.38.2.tar.gz
       win-64:
@@ -797,7 +797,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stdlib-list-0.12.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
@@ -860,6 +859,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h3a581c9_11.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/25/9d/2e8d27c5c012fcddef8ac4d0b79c7f791a602bab637f9a3530c65bacf865/squeaky-0.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/19/f519ef8aa2f379935a44212c5744e2b3a46173bf04e0110fb7f4af4028c9/scour-0.38.2.tar.gz
   testjax:
@@ -1053,7 +1053,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -1062,6 +1061,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/57/1e/63ac22ec535e08129e16cb71b7eeeb8816c01d627ea1bc9105e925a71da0/jax-0.9.0.1-py3-none-any.whl
@@ -1105,7 +1105,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -1205,6 +1204,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a0/5429411bb6fbc279c574fae2f404439b13c037587305babfb83ea05b1b0e/kahypar-1.3.7-cp313-cp313-macosx_11_0_arm64.whl
@@ -1404,7 +1404,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -1413,6 +1412,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/b3/ae616300dafc8534fba5497dace380350ec5cb96ebcf4d43fc1ece94013b/kahypar-1.3.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
@@ -1452,7 +1452,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -1552,6 +1551,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-ng-2.3.3-h8bce59a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/67/17/2c2f1d745f71b2d6c711cf39fc641af5b28fb7b59fdff009e50976a999ec/cotengrust-0.2.1-cp313-cp313-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
@@ -1590,7 +1590,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -1690,6 +1689,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a0/5429411bb6fbc279c574fae2f404439b13c037587305babfb83ea05b1b0e/kahypar-1.3.7-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/ce/27a981616555f79ee97c8abe03715808c47610106f1babe7cf736a7713a8/cotengrust-0.2.1-cp313-cp313-macosx_11_0_arm64.whl
@@ -1728,7 +1728,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyha7b4d00_0.conda
@@ -1843,6 +1842,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-ng-2.3.3-h0261ad2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/52/38dedd2c198ff7409074065da9397eaf27d7a5fc1dd21dffa9c23baa4bdc/cotengrust-0.2.1-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
@@ -2038,7 +2038,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -2047,6 +2046,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/56/3270fe6e034d2bbac5aae99e1671bdfdd327b11003935e58460cea67738c/kahypar-1.3.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6e/33/945bf36a389ff648ba78ccafa4bc4f79f75a2fc321d23f6a14a29e7ba94e/cotengrust-0.2.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -2087,7 +2087,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -2187,6 +2186,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-ng-2.3.3-h8bce59a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/78/82827f765809b3a8a780a97798a05ce068263736118ee0f145cc087b24bb/cotengrust-0.2.1-cp314-cp314-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
@@ -2226,7 +2226,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -2326,6 +2325,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/f7/9b8303f7af45d0ab1f4bdbeef3a93e777dea662f6af441f656a007d73571/kahypar-1.3.7-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
@@ -2365,7 +2365,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyha7b4d00_0.conda
@@ -2480,6 +2479,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-ng-2.3.3-h0261ad2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/89/bb322a450b65bb993824317634ce9bd048e1c4829d7e77672ecd363197c9/cotengrust-0.2.1-cp314-cp314-win_amd64.whl
@@ -2675,7 +2675,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -2684,6 +2683,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ac/61/113d63a545b195423b927c74c967e6c96bc7f8626ac9a624e00ce86235d2/kahypar-1.3.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
@@ -2723,7 +2723,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -2823,6 +2822,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-ng-2.3.3-h8bce59a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/1c/f261c800ce7c93f8aec95a68b65e9a59ca41e60b787a3c4b4110de2a19d1/cotengrust-0.2.1-cp311-cp311-macosx_10_12_x86_64.whl
@@ -2861,7 +2861,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -2961,6 +2960,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/04/84/ad742f6b78a4a9e03c00f0ffe6632212c5b9aa42b9baebc7d70cc315e977/cotengrust-0.2.1-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
@@ -2999,7 +2999,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyha7b4d00_0.conda
@@ -3114,6 +3113,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-ng-2.3.3-h0261ad2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/2b/975af8324447c9ea7aa7e8d1904ff3de647b656051d84f1cca7388103aae/cotengrust-0.2.1-cp311-cp311-win_amd64.whl
@@ -3349,7 +3349,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.6-h4df99d1_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -3358,6 +3357,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
   testtensorflow:
@@ -3552,7 +3552,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -3561,6 +3560,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/09/b9/f668bc51129c0fec7728ae8b43180417fe1c1fe99f71d302739f6cc50944/optree-0.19.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
@@ -3627,7 +3627,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -3727,6 +3726,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/04/84/ad742f6b78a4a9e03c00f0ffe6632212c5b9aa42b9baebc7d70cc315e977/cotengrust-0.2.1-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
@@ -3949,7 +3949,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -3958,6 +3957,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/07/42/2c3ac59253ae8892b6f307875263dd23dc875cdf732d3aea40d6d41fb7cb/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -4023,7 +4023,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
@@ -4123,6 +4122,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./
+      - pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a0/5429411bb6fbc279c574fae2f404439b13c037587305babfb83ea05b1b0e/kahypar-1.3.7-cp313-cp313-macosx_11_0_arm64.whl
@@ -10702,19 +10702,6 @@ packages:
   run_exports: {}
   size: 27202
   timestamp: 1761343475105
-- conda: https://conda.anaconda.org/conda-forge/noarch/symmray-0.3.0-pyhd8ed1ab_0.conda
-  sha256: 295dc366088ede1e688408dd51c790c006292bec37305f4af36b663be093ac99
-  md5: a1d2a1b304df66ef9c5d061e13129fe2
-  depends:
-  - autoray
-  - cotengra
-  - python >=3.11
-  license: Apache-2.0
-  purls:
-  - pkg:pypi/symmray?source=hash-mapping
-  run_exports: {}
-  size: 107541
-  timestamp: 1787496223189
 - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
   sha256: 3f661e98a09f976775a494488beb3d35ebb00f535b169c6bd891f2e280d55783
   md5: 3b887b7b3468b0f494b4fad40178b043
@@ -18584,6 +18571,27 @@ packages:
   - coverage ; extra == 'tests'
   - pytest ; extra == 'tests'
   - pytest-cov ; extra == 'tests'
+  requires_python: '>=3.11'
+- pypi: git+https://github.com/jcmgray/symmray.git?branch=main#a17699db692e2471c86d74158acf86c2e619298f
+  name: symmray
+  version: 0.3.2.dev6+ga17699db6
+  requires_dist:
+  - autoray>=0.8.10
+  - astroid ; extra == 'docs'
+  - furo ; extra == 'docs'
+  - ipython ; extra == 'docs'
+  - myst-nb ; extra == 'docs'
+  - setuptools-scm ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - sphinx-autoapi ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - cotengra ; extra == 'testing'
+  - coverage ; extra == 'testing'
+  - einops ; extra == 'testing'
+  - numpy ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - quimb ; extra == 'testing'
   requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/04/84/ad742f6b78a4a9e03c00f0ffe6632212c5b9aa42b9baebc7d70cc315e977/cotengrust-0.2.1-cp311-cp311-macosx_11_0_arm64.whl
   name: cotengrust

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,11 +125,12 @@ numba = "*"
 numpy = "*"
 psutil = "*"
 scipy = ">=1.16.0"
-symmray = "*"
 tqdm = "*"
 
 [tool.pixi.pypi-dependencies]
 quimb = { path = ".", editable = true }
+# temporary
+symmray = { git = "https://github.com/jcmgray/symmray.git", branch = "main" }
 
 [tool.pixi.feature.full.dependencies]
 autograd= "*"

--- a/quimb/tensor/tn1d/compress.py
+++ b/quimb/tensor/tn1d/compress.py
@@ -380,6 +380,20 @@ def _form_final_tn_from_tensor_sequence(
     return new
 
 
+def _phase_dm_operator(rho: Tensor, left_inds, right_inds):
+    """Apply fermionic signs before decomposing ``rho``.
+
+    If the first left index is not dual, flip all right indices. This makes
+    the kept eigenspace match a direct SVD.
+    """
+    data = rho.data
+    if not data.indices[rho.inds.index(left_inds[0])].dual:
+        axes_to_flip = tuple(
+            axis for axis, ind in enumerate(rho.inds) if ind in right_inds
+        )
+        rho.modify(data=data.phase_flip(*axes_to_flip))
+
+
 def tensor_network_1d_compress_dm(
     tn: TensorNetwork,
     max_bond=None,
@@ -581,15 +595,7 @@ def tensor_network_1d_compress_dm(
         rhoi = tensor_contract(*rho_tensors, **contract_opts)
 
         if fermion:
-            # phase flip dual bra-side axes so rhoi is positive
-            data = rhoi.data
-            axs_flip = tuple(
-                ax
-                for ax, ix in enumerate(rhoi.inds)
-                if (ix in right_inds) and data.indices[ax].dual
-            )
-            if axs_flip:
-                rhoi.modify(data=data.phase_flip(*axs_flip))
+            _phase_dm_operator(rhoi, left_inds, right_inds)
 
         # construct the conjugate projector separately below
         bix = rand_uuid()
@@ -1108,8 +1114,8 @@ def _conj_project(tq: Tensor, bond_ind: str) -> Tensor:
     tqc = tq.copy()
 
     if tq.isfermionic():
-        axis = tq.inds.index(bond_ind)
-        tqc.modify(data=tq.data.conj_project(axis=axis))
+        axes = tq.inds.index(bond_ind)
+        tqc.modify(data=tq.data.conj_project(axes=axes))
     else:
         tqc.conj_()
 
@@ -2346,6 +2352,19 @@ def tensor_network_1d_compress_srcmps_oversample(
 # ---------------------------- fitting methods ------------------------------ #
 
 
+def _conjugate_fit_update(fit_update: Tensor) -> None:
+    """Conjugate a local fit update in place.
+
+    For fermionic data, also phase every dual axis of the update. This
+    includes exposed fit bonds. It is a local adjoint, not the network-level
+    conjugation used to build the overlap.
+    """
+    if fit_update.isfermionic():
+        fit_update.modify(data=fit_update.data.conj(phase_dual=True))
+    else:
+        fit_update.conj_()
+
+
 def _tn1d_fit_sum_sweep_1site(
     tn_fit: TensorNetwork,
     tn_overlaps: list[TensorNetwork],
@@ -2365,15 +2384,6 @@ def _tn1d_fit_sum_sweep_1site(
 
     N = len(site_tags)
     K = len(tn_overlaps)
-
-    fermion = tn_fit.isfermionic()
-    if fermion and any(
-        t.data.dummy_modes for tn_o in tn_overlaps for t in tn_o
-    ):
-        warnings.warn(
-            "1-site fitting of fermionic tensor networks with tensors of odd "
-            "parity is likely incorrect, use 2-site (`bsz=2`)."
-        )
 
     if max_bond is not None:
         current_bond_dim = tn_fit.max_bond()
@@ -2465,7 +2475,7 @@ def _tn1d_fit_sum_sweep_1site(
             else:
                 tfinew += tfiknew
 
-        tfinew.conj_()
+        _conjugate_fit_update(tfinew)
 
         if compute_tdiff:
             # track change in tensor norm
@@ -2557,8 +2567,6 @@ def _tn1d_fit_sum_sweep_2site(
         right_inds = tuple(ix for ix in tfi1.inds if ix != bond)
         tfinew = None
 
-        fermion = tfi0.isfermionic()
-
         for k, tn_overlap in enumerate(tn_overlaps):
             # form local overlap
             tnik = (
@@ -2582,11 +2590,7 @@ def _tn1d_fit_sum_sweep_2site(
             else:
                 tfinew += tfiknew
 
-        if fermion:
-            # also flips the dual indices
-            tfinew.modify(data=tfinew.data.conj(phase_dual=True))
-        else:
-            tfinew.conj_()
+        _conjugate_fit_update(tfinew)
 
         tfinew0, tfinew1 = tfinew.split(
             max_bond=max_bond,
@@ -2609,12 +2613,6 @@ def _tn1d_fit_sum_sweep_2site(
         tfinew1.transpose_like_(tfi1)
         tfi0.modify(data=tfinew0.data, left_inds=tfinew0.left_inds)
         tfi1.modify(data=tfinew1.data, left_inds=tfinew1.left_inds)
-
-        if fermion:
-            # deal with the global signs generated during conjugation
-            for ts in (tfi0 | tfi1).tensors:
-                if sum(m.parity for m in ts.data.dummy_modes) % 2 == 1:
-                    ts.data.phase_global(inplace=True)
 
     return max_tdiff
 
@@ -2939,6 +2937,11 @@ def tensor_network_1d_compress_fit(
 
     tn_fit.drop_tags("__FIT__")
     tn_fit.conj_()
+    if tn_fit.isfermionic():
+        # correct the sign from double fermionic conjugation
+        total_dummy_parity = sum(t.data.dummy_parity for t in tn_fit)
+        t = tn_fit[site_tags[0]]
+        t.modify(data=t.data.phase_global(parity=total_dummy_parity))
 
     if normalize:
         if reverse:

--- a/tests/test_tensor/__init__.py
+++ b/tests/test_tensor/__init__.py
@@ -31,3 +31,52 @@ pytorch_case = pytest.param(
     "torch",
     marks=pytest.mark.skipif(not found_torch, reason="pytorch not installed"),
 )
+
+requires_symmray = pytest.mark.skipif(
+    importlib.util.find_spec("symmray") is None,
+    reason="symmray not installed",
+)
+
+# scalar 2D networks for exact compression tests
+symmetry_cases = [
+    "abelian",
+    "fermionic-even",
+    "fermionic-odd-checker",
+    "fermionic-odd-diag",
+]
+
+# uniform and mixed bond orientations
+bond_orientations = ["reversed", "canonical", "random"]
+
+site_charge_cases = {
+    # odd checkerboard sites; even total charge
+    "fermionic-odd-checker": lambda site: (site[0] + site[1]) % 2,
+    # odd diagonal sites; even total charge
+    "fermionic-odd-diag": lambda site: int(site[0] == site[1]),
+}
+
+
+def make_symmetric_2d_tn(
+    symmetry,
+    duals="reversed",
+    Lx=4,
+    Ly=4,
+    bond_dim=2,
+    seed=42,
+    dist="normal",
+):
+    """Make a scalar Z2-symmetric 2D tensor network for tests."""
+    import symmray as sr
+
+    return sr.TN2D_abelian_rand(
+        symmetry="Z2",
+        Lx=Lx,
+        Ly=Ly,
+        bond_dim=bond_dim,
+        phys_dim=None,
+        fermionic=symmetry != "abelian",
+        site_charge=site_charge_cases.get(symmetry),
+        duals=duals,
+        seed=seed,
+        dist=dist,
+    )

--- a/tests/test_tensor/test_tn1d/test_compress.py
+++ b/tests/test_tensor/test_tn1d/test_compress.py
@@ -1,5 +1,3 @@
-import importlib.util
-
 import autoray as ar
 import numpy as np
 import pytest
@@ -7,60 +5,50 @@ import pytest
 import quimb as qu
 import quimb.tensor as qtn
 
-from .. import jax_case, pytorch_case
+from .. import (
+    bond_orientations,
+    jax_case,
+    make_symmetric_2d_tn,
+    pytorch_case,
+    requires_symmray,
+    symmetry_cases,
+)
 
 dtypes = ["float32", "float64", "complex64", "complex128"]
 
-requires_symmray = pytest.mark.skipif(
-    importlib.util.find_spec("symmray") is None,
-    reason="symmray not installed",
-)
-
-symmetries = [
-    "abelian",
-    "fermionic-even",
-    "fermionic-odd-checker",
-    "fermionic-odd-diag",
-]
-
-
-def symmetric_2d_tn(symmetry, Lx, Ly, bond_dim=2, seed=42):
-    """Build a scalar Z2-symmetric ``TensorNetwork2D`` test case."""
-    import symmray as sr
-
-    if symmetry == "fermionic-odd-checker":
-
-        def site_charge(site):
-            return (site[0] + site[1]) % 2
-
-    elif symmetry == "fermionic-odd-diag":
-
-        def site_charge(site):
-            return int(site[0] == site[1])
-
-    else:
-
-        def site_charge(site):
-            return 0
-
-    tn = sr.TN_abelian_from_edges_rand(
-        symmetry="Z2",
-        edges=qtn.edges_2d_square(Lx, Ly),
-        bond_dim=bond_dim,
-        phys_dim=None,
-        fermionic=symmetry != "abelian",
-        site_tag_id="I{},{}",
-        site_charge=site_charge,
-        seed=seed,
-    )
-    for i in range(Lx):
-        for j in range(Ly):
-            tn[f"I{i},{j}"].add_tag(f"X{i}")
-            tn[f"I{i},{j}"].add_tag(f"Y{j}")
-
-    return tn.view_as_(
-        qtn.TensorNetwork2D, Lx=Lx, Ly=Ly, x_tag_id="X{}", y_tag_id="Y{}"
-    )
+# compression options, including fit sweep counts
+boundary_options = {
+    "direct": {"mode": "direct"},
+    "dm": {"mode": "dm"},
+    "zipup": {"mode": "zipup"},
+    "zipup-oversample": {"mode": "zipup-oversample"},
+    "sdc": {"mode": "sdc"},
+    "sdc-oversample": {"mode": "sdc-oversample"},
+    "fit-bsz1": {
+        "mode": "fit",
+        "bsz": 1,
+        "tn_fit": "zipup",
+        "max_iterations": 6,
+    },
+    "fit-bsz2": {
+        "mode": "fit",
+        "bsz": 2,
+        "tn_fit": "zipup",
+        "max_iterations": 6,
+    },
+    "fit-bsz2-odd-iters": {
+        "mode": "fit",
+        "bsz": 2,
+        "tn_fit": "zipup",
+        "max_iterations": 5,
+    },
+    "fit-bsz1-odd-iters": {
+        "mode": "fit",
+        "bsz": 1,
+        "tn_fit": "zipup",
+        "max_iterations": 5,
+    },
+}
 
 
 @pytest.fixture(scope="module")
@@ -174,55 +162,35 @@ def test_sdc_backend(method, backend):
 
 
 @requires_symmray
-@pytest.mark.parametrize("symmetry", symmetries)
-@pytest.mark.parametrize(
-    "method",
-    [
-        "direct",
-        "dm",
-        "zipup",
-        "zipup-oversample",
-        "sdc",
-        "sdc-oversample",
-        "fit-bsz1",
-        "fit-bsz2",
-    ],
-)
-@pytest.mark.parametrize("from_which", ["xmin", "xmax", "ymin", "ymax"])
-def test_symmetric_boundary_contract(method, symmetry, from_which, request):
-    """Every 1D compression method should exactly contract a scalar symmetric
-    2D network, given enough bond dimension, whatever the parity of its
-    tensors or the side contracted from.
+@pytest.mark.parametrize("method", boundary_options)
+@pytest.mark.parametrize("symmetry", symmetry_cases)
+@pytest.mark.parametrize("bond_orientation", bond_orientations)
+@pytest.mark.parametrize("direction", ["xmin", "xmax", "ymin", "ymax"])
+def test_symmetric_boundary_contract(
+    method, symmetry, bond_orientation, direction
+):
+    """Check exact 1D compression of a scalar symmetric 2D network.
+
+    Cover tensor parity, bond orientation, and contraction direction. Use
+    enough bond dimension to prevent truncation.
     """
-    if (method, symmetry) == ("fit-bsz1", "fermionic-odd-diag"):
-        # only some directions are affected, so not strict
-        request.applymarker(
-            pytest.mark.xfail(
-                reason="1-site fitting is wrong for odd parity", strict=False
-            )
-        )
-
-    tn = symmetric_2d_tn(symmetry, 4, 4)
-
-    opts = {"mode": method}
-    if method.startswith("fit"):
-        opts = {
-            "mode": "fit",
-            "bsz": int(method[-1]),
-            "tn_fit": "zipup",
-            "max_iterations": 6,
-        }
-
-    contract_opts = {
-        # enough that nothing is discarded
-        "max_bond": 4,
-        "cutoff": 0.0,
-        "sequence": (from_which,),
-        **opts,
-    }
+    # use distinct random data for each case
+    seed = qu.utils.hash_kwargs_to_int(
+        method=method,
+        symmetry=symmetry,
+        bond_orientation=bond_orientation,
+        direction=direction,
+    )
+    tn = make_symmetric_2d_tn(symmetry, duals=bond_orientation, seed=seed)
 
     expected = tn.contract(all, optimize="auto-hq")
-    value = tn.contract_boundary(**contract_opts)
+    value = tn.contract_boundary(
+        # prevent truncation
+        max_bond=4,
+        cutoff=0.0,
+        sequence=(direction,),
+        **boundary_options[method],
+    )
     assert value == pytest.approx(expected, rel=1e-10)
 
 
@@ -263,15 +231,31 @@ def test_fmps_mpo_fitting(
 
 
 @requires_symmray
-@pytest.mark.parametrize("symmetry", symmetries)
-@pytest.mark.parametrize("from_which", ["xmin", "xmax", "ymin", "ymax"])
-def test_dm_truncating_matches_direct(symmetry, from_which):
-    """Check DM truncation against direct compression."""
-    # choose a network and bond limit that force truncation
-    tn = symmetric_2d_tn(symmetry, 6, 6)
-    opts = {"max_bond": 4, "cutoff": 0.0, "sequence": (from_which,)}
-    value_dm = tn.contract_boundary(mode="dm", **opts)
-    value_direct = tn.contract_boundary(mode="direct", **opts)
+@pytest.mark.parametrize("symmetry", symmetry_cases)
+@pytest.mark.parametrize("bond_orientation", bond_orientations)
+@pytest.mark.parametrize("direction", ["xmin", "xmax", "ymin", "ymax"])
+def test_dm_truncating_matches_direct(symmetry, bond_orientation, direction):
+    """Check that truncated DM compression matches direct compression."""
+    seed = qu.utils.hash_kwargs_to_int(
+        symmetry=symmetry,
+        bond_orientation=bond_orientation,
+        direction=direction,
+    )
+    # this network and bond limit force truncation
+    tn = make_symmetric_2d_tn(
+        symmetry,
+        duals=bond_orientation,
+        Lx=6,
+        Ly=6,
+        seed=seed,
+    )
+    contraction_options = {
+        "max_bond": 4,
+        "cutoff": 0.0,
+        "sequence": (direction,),
+    }
+    value_dm = tn.contract_boundary(mode="dm", **contraction_options)
+    value_direct = tn.contract_boundary(mode="direct", **contraction_options)
     assert value_dm == pytest.approx(value_direct, rel=1e-8)
 
 

--- a/tests/test_tensor/test_tn2d/test_core.py
+++ b/tests/test_tensor/test_tn2d/test_core.py
@@ -8,6 +8,13 @@ from numpy.testing import assert_allclose
 import quimb as qu
 import quimb.tensor as qtn
 
+from .. import (
+    bond_orientations,
+    make_symmetric_2d_tn,
+    requires_symmray,
+    symmetry_cases,
+)
+
 
 class TestPEPSConstruct:
     @pytest.mark.parametrize("Lx", [3, 4, 5])
@@ -324,6 +331,59 @@ class Test2DContract:
         xe = norm.contract(all, optimize="auto-hq")
         xt = norm.contract_hotrg(max_bond=5)
         assert xt == pytest.approx(xe, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        "bond_dim,max_bond,dist,tolerance",
+        [
+            pytest.param(2, None, "normal", 1e-10, id="untruncated"),
+            # local rank is up to 16, so max_bond=8 truncates
+            pytest.param(4, 8, "uniform", 0.1, id="truncated"),
+        ],
+    )
+    @requires_symmray
+    @pytest.mark.parametrize("symmetry", symmetry_cases)
+    @pytest.mark.parametrize("bond_orientation", bond_orientations)
+    @pytest.mark.parametrize("direction", ["x", "y"])
+    def test_contract_hotrg_symmetric(
+        self,
+        symmetry,
+        bond_orientation,
+        direction,
+        bond_dim,
+        max_bond,
+        dist,
+        tolerance,
+    ):
+        """Check exact and truncated HOTRG contraction.
+
+        Cover tensor parity, bond orientation, and coarse-graining direction.
+        Uniform data gives a stable approximation when truncating.
+        """
+        seed = qu.utils.hash_kwargs_to_int(
+            method="hotrg",
+            symmetry=symmetry,
+            bond_orientation=bond_orientation,
+            direction=direction,
+            bond_dim=bond_dim,
+            max_bond=max_bond,
+            dist=dist,
+        )
+        tn = make_symmetric_2d_tn(
+            symmetry,
+            duals=bond_orientation,
+            bond_dim=bond_dim,
+            seed=seed,
+            dist=dist,
+        )
+
+        expected = tn.contract(all, optimize="auto-hq")
+        value = tn.contract_hotrg(
+            max_bond=max_bond,
+            cutoff=0.0,
+            sequence=(direction,),
+            reduce_opts={"method": "eigh"},
+        )
+        assert value == pytest.approx(expected, rel=tolerance)
 
     def test_ising_accuracy_regression(self):
         tn = qtn.TN2D_classical_ising_partition_function(16, 16, 0.44)

--- a/tests/test_tensor/test_tnag/test_compress.py
+++ b/tests/test_tensor/test_tnag/test_compress.py
@@ -1,13 +1,14 @@
-import importlib.util
-
 import pytest
 
+import quimb as qu
 import quimb.tensor as qtn
 from quimb.tensor.tnag.compress import tensor_network_ag_compress
 
-requires_symmray = pytest.mark.skipif(
-    importlib.util.find_spec("symmray") is None,
-    reason="symmray not installed",
+from .. import (
+    bond_orientations,
+    make_symmetric_2d_tn,
+    requires_symmray,
+    symmetry_cases,
 )
 
 
@@ -37,81 +38,52 @@ def test_compress_projector_bp_canonize():
 
 
 @requires_symmray
-@pytest.mark.parametrize(
-    "symmetry",
-    [
-        "abelian",
-        "fermionic-even",
-        "fermionic-odd-checker",
-        "fermionic-odd-diag",
-    ],
-)
+@pytest.mark.parametrize("symmetry", symmetry_cases)
 @pytest.mark.parametrize("canonize", [False, True, "layered", "bp"])
-@pytest.mark.parametrize("from_which", ["xmin", "xmax", "ymin", "ymax"])
-def test_compress_projector_symmetric(symmetry, canonize, from_which, request):
-    """Boundary contracting a scalar symmetric network with locally computed
-    projectors should be exact, given enough bond dimension, however the
-    network is preconditioned.
+@pytest.mark.parametrize("bond_orientation", bond_orientations)
+@pytest.mark.parametrize("direction", ["xmin", "xmax", "ymin", "ymax"])
+def test_compress_projector_symmetric(
+    symmetry, canonize, bond_orientation, direction, request
+):
+    """Check exact boundary contraction with local projectors.
+
+    Cover each preconditioner, bond orientation, and contraction direction.
+    Use enough bond dimension to prevent truncation.
     """
-    import symmray as sr
+    canonize_opts = None
+    if canonize == "bp":
+        # isolate phase errors with a tightly converged BP gauge
+        canonize_opts = {"max_iterations": 1000, "tol": 5e-13}
 
-    fermionic = symmetry != "abelian"
-
-    if canonize == "bp" and fermionic and from_which in ("xmax", "ymax"):
-        # inserting the messages still picks up an overall sign in some
-        # regions, leaving the squared operator minus a positive operator,
-        # which `compute_reduced_factor` assumes it is not
-        request.applymarker(
-            pytest.mark.xfail(
-                reason="bp message insertion signs some regions", strict=True
+        if symmetry != "abelian":
+            # BP messages do not retain the full fermionic phase frame
+            request.applymarker(
+                pytest.mark.xfail(
+                    reason="BP messages lose the fermionic phase frame",
+                    strict=False,
+                )
             )
-        )
 
-    if symmetry == "fermionic-odd-checker":
-        # checkerboard of odd sites, keeping the total charge even
-        def site_charge(site):
-            return (site[0] + site[1]) % 2
-
-    elif symmetry == "fermionic-odd-diag":
-        # odd sites on the diagonal, keeping the total charge even
-        def site_charge(site):
-            return int(site[0] == site[1])
-
-    else:
-
-        def site_charge(site):
-            return 0
-
-    Lx = Ly = 4
-
-    tn = sr.TN_abelian_from_edges_rand(
-        symmetry="Z2",
-        edges=qtn.edges_2d_square(Lx, Ly),
-        bond_dim=2,
-        phys_dim=None,
-        fermionic=fermionic,
-        site_tag_id="I{},{}",
-        site_charge=site_charge,
-        seed=42,
+    # use distinct random data for each case
+    seed = qu.utils.hash_kwargs_to_int(
+        symmetry=symmetry,
+        canonize=canonize,
+        bond_orientation=bond_orientation,
+        direction=direction,
     )
-    for i in range(Lx):
-        for j in range(Ly):
-            tn[f"I{i},{j}"].add_tag(f"X{i}")
-            tn[f"I{i},{j}"].add_tag(f"Y{j}")
-    tn.view_as_(
-        qtn.TensorNetwork2D, Lx=Lx, Ly=Ly, x_tag_id="X{}", y_tag_id="Y{}"
-    )
+    tn = make_symmetric_2d_tn(symmetry, duals=bond_orientation, seed=seed)
 
     expected = tn.contract(all, optimize="auto-hq")
 
     # `contract_boundary` routes this to `tensor_network_ag_compress`
     value = tn.contract_boundary(
-        # enough that nothing is discarded
+        # prevent truncation
         max_bond=8,
         cutoff=0.0,
         mode="projector",
         canonize=canonize,
-        sequence=(from_which,),
+        canonize_opts=canonize_opts,
+        sequence=(direction,),
     )
 
     assert value == pytest.approx(expected, rel=1e-10)


### PR DESCRIPTION
This PR includes fixes for fermionic compression and contraction.

- The 'dm' method should now be fully compatible with fermionic contractions involving mixed bond orientations and dummy modes
- The 'fit' method, both bsz=1 and bsz=2, should also now be fully compatible with fermionic contractions involving mixed bond orientations and dummy modes
- The test matrix has been updated to cover more TN2D fermionic contractions in a systematic way, including 2D HOTRG contraction (https://github.com/jcmgray/symmray/issues/48)